### PR TITLE
[Fix]견적서 작성 시 request테이블 상태변경(DURI-230)

### DIFF
--- a/app/src/main/java/kr/com/duri/groomer/application/facade/QuotationFacade.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/facade/QuotationFacade.java
@@ -21,5 +21,8 @@ public class QuotationFacade {
 
         // 2. QuotationService를 사용하여 견적서 저장
         quotationService.saveQuotation(request, quotationRequest);
+
+        // 3. 요청 상태를 APPROVED로 업데이트
+        requestService.updateRequestStatusToApproved(request.getId());
     }
 }

--- a/app/src/main/java/kr/com/duri/user/application/service/RequestService.java
+++ b/app/src/main/java/kr/com/duri/user/application/service/RequestService.java
@@ -8,4 +8,6 @@ public interface RequestService {
     Request getRequestById(Long requestId);
 
     List<Request> getNewRequestsByShopId(Long shopId);
+
+    void updateRequestStatusToApproved(Long requestId);
 }

--- a/app/src/main/java/kr/com/duri/user/application/service/RequestServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/user/application/service/RequestServiceImpl.java
@@ -26,4 +26,11 @@ public class RequestServiceImpl implements RequestService {
     public List<Request> getNewRequestsByShopId(Long shopId) {
         return requestRepository.findNewRequestsByShopId(shopId);
     }
+
+    @Override
+    public void updateRequestStatusToApproved(Long requestId) {
+        Request existingRequest = getRequestById(requestId);
+        Request updatedRequest = existingRequest.withApprovedStatus();
+        requestRepository.save(updatedRequest);
+    }
 }

--- a/app/src/main/java/kr/com/duri/user/domain/entity/Request.java
+++ b/app/src/main/java/kr/com/duri/user/domain/entity/Request.java
@@ -1,7 +1,6 @@
 package kr.com.duri.user.domain.entity;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
 import kr.com.duri.common.entity.BaseEntity;
 import kr.com.duri.groomer.domain.entity.Shop;
 import kr.com.duri.user.domain.Enum.QuotationStatus;
@@ -35,7 +34,7 @@ public class Request extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private QuotationStatus status; // 상태 (대기(W), 승인(A), 만료(E))
 
-    //APPROVED로 상태변화
+    // APPROVED로 상태변화
     public Request withApprovedStatus() {
         return Request.builder()
                 .id(this.id)

--- a/app/src/main/java/kr/com/duri/user/domain/entity/Request.java
+++ b/app/src/main/java/kr/com/duri/user/domain/entity/Request.java
@@ -23,18 +23,25 @@ public class Request extends BaseEntity {
     @Column(name = "request_id")
     private Long id; // 견적서 ID
 
-    @NotBlank
     @ManyToOne
     @JoinColumn(name = "quotation_id")
     private QuotationReq quotation; // 견적요청서 ID (FK)
 
-    @NotBlank
     @ManyToOne
     @JoinColumn(name = "shop_id")
     private Shop shop; // 매장 ID (FK)
 
-    @NotBlank
     @Column(name = "request_status")
     @Enumerated(EnumType.STRING)
     private QuotationStatus status; // 상태 (대기(W), 승인(A), 만료(E))
+
+    //APPROVED로 상태변화
+    public Request withApprovedStatus() {
+        return Request.builder()
+                .id(this.id)
+                .quotation(this.quotation)
+                .shop(this.shop)
+                .status(QuotationStatus.APPROVED) // 상태 변경
+                .build();
+    }
 }


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- 

## PR 개요

- 기존 DURI-230 견적서 작성 -> request테이블이 그대로 WAITING이 됨
- 미용사가 견적서 작성 시 REQUEST 테이블 상태가 APPROVED로 바뀌어서 견적서가 작성됨을 저장함

## Screenshots

<!--
  If capable,
  If there are UI changes, include before and after screenshots.
  This helps reviewers understand the visual impact of the changes.
-->