### PR TITLE
[Feat] 보낸 견적서 상세 조회 API(DURI-316)

### DIFF
--- a/app/src/main/java/kr/com/duri/groomer/application/dto/response/QuotationDetailResponse.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/response/QuotationDetailResponse.java
@@ -1,0 +1,23 @@
+package kr.com.duri.groomer.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import kr.com.duri.groomer.application.dto.request.QuotationRequest;
+import kr.com.duri.user.application.dto.response.MenuDetailResponse;
+import kr.com.duri.user.application.dto.response.PetDetailResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class QuotationDetailResponse {
+    private QuotationShopDetailResponse shopDetail; // 매장 정보
+    private LocalDateTime quotationCreatedAt; // 견적서 작성일
+    private PetDetailResponse petDetail; // 반려견 정보
+    private MenuDetailResponse menuDetail; // 메뉴 정보
+    private QuotationRequest quotation; // 견적서 정보
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/response/QuotationShopDetailResponse.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/response/QuotationShopDetailResponse.java
@@ -1,0 +1,18 @@
+package kr.com.duri.groomer.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class QuotationShopDetailResponse {
+
+    private String shopName; // 매장이름
+    private String shopAddress; // 매장 주소
+    private String shopPhone; // 매장 전화번호
+    private String groomerName; // 디자이너 이름
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/facade/QuotationFacade.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/facade/QuotationFacade.java
@@ -2,10 +2,15 @@ package kr.com.duri.groomer.application.facade;
 
 import kr.com.duri.groomer.application.dto.request.QuotationRequest;
 import kr.com.duri.groomer.application.dto.request.QuotationUpdateRequest;
+import kr.com.duri.groomer.application.dto.response.QuotationDetailResponse;
 import kr.com.duri.groomer.application.mapper.QuotationMapper;
+import kr.com.duri.groomer.application.service.GroomerService;
 import kr.com.duri.groomer.application.service.QuotationService;
+import kr.com.duri.groomer.domain.entity.Groomer;
 import kr.com.duri.groomer.domain.entity.Quotation;
+import kr.com.duri.groomer.domain.entity.Shop;
 import kr.com.duri.user.application.service.QuotationReqService;
+import kr.com.duri.user.domain.entity.Pet;
 import kr.com.duri.user.domain.entity.Request;
 import lombok.RequiredArgsConstructor;
 
@@ -17,6 +22,7 @@ public class QuotationFacade {
 
     private final QuotationReqService requestService;
     private final QuotationService quotationService;
+    private final GroomerService groomerService;
     private final QuotationMapper quotationMapper;
 
     public void createQuotation(QuotationRequest quotationRequest) {
@@ -44,5 +50,21 @@ public class QuotationFacade {
 
         // 3. 업데이트된 엔티티 저장
         quotationService.updateQuotation(existingQuotation);
+    }
+
+    public QuotationDetailResponse getQuotationDetail(Long requestId) {
+        // 1. request조회
+        Request request = requestService.getRequestById(requestId);
+
+        // 2. Shop 및 Groomer 조회
+        Shop shop = request.getShop();
+        Groomer groomer = groomerService.getGroomerByShopId(shop.getId());
+
+        // 3. Pet 및 Quotation 조회
+        Pet pet = request.getQuotation().getPet();
+        Quotation quotation = quotationService.findByRequestId(requestId);
+
+        // 4. DTO조합
+        return quotationMapper.toQuotationDetailResponse(request, shop, groomer, pet, quotation);
     }
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/service/QuotationService.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/QuotationService.java
@@ -9,4 +9,6 @@ public interface QuotationService {
     Quotation findQuotationById(Long quotationId);
 
     void updateQuotation(Quotation quotation);
+
+    Quotation findByRequestId(Long requestId);
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/service/QuotationServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/QuotationServiceImpl.java
@@ -3,7 +3,9 @@ package kr.com.duri.groomer.application.service;
 import kr.com.duri.groomer.domain.entity.Quotation;
 import kr.com.duri.groomer.exception.QuotationExistsException;
 import kr.com.duri.groomer.exception.QuotationNotFoundException;
+import kr.com.duri.groomer.repository.GroomerRepository;
 import kr.com.duri.groomer.repository.QuotationRepository;
+import kr.com.duri.user.repository.RequestRepository;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -13,6 +15,8 @@ import org.springframework.stereotype.Service;
 public class QuotationServiceImpl implements QuotationService {
 
     private final QuotationRepository quotationRepository;
+    private final RequestRepository requestRepository;
+    private final GroomerRepository groomerRepository;
 
     @Override
     public void saveQuotation(Quotation quotation) {
@@ -34,5 +38,12 @@ public class QuotationServiceImpl implements QuotationService {
     @Override
     public void updateQuotation(Quotation quotation) {
         quotationRepository.save(quotation);
+    }
+
+    @Override
+    public Quotation findByRequestId(Long requestId) {
+        return quotationRepository
+                .findByRequestId(requestId)
+                .orElseThrow(() -> new QuotationNotFoundException("해당 견적을 찾을 수 없습니다."));
     }
 }

--- a/app/src/main/java/kr/com/duri/groomer/controller/QuotationController.java
+++ b/app/src/main/java/kr/com/duri/groomer/controller/QuotationController.java
@@ -3,6 +3,7 @@ package kr.com.duri.groomer.controller;
 import kr.com.duri.common.response.CommonResponseEntity;
 import kr.com.duri.groomer.application.dto.request.QuotationRequest;
 import kr.com.duri.groomer.application.dto.request.QuotationUpdateRequest;
+import kr.com.duri.groomer.application.dto.response.QuotationDetailResponse;
 import kr.com.duri.groomer.application.facade.QuotationFacade;
 import lombok.RequiredArgsConstructor;
 
@@ -30,5 +31,12 @@ public class QuotationController {
             @RequestBody QuotationUpdateRequest quotationUpdateRequest) {
         quotationFacade.updateQuotation(quotationId, quotationUpdateRequest);
         return CommonResponseEntity.success("견적서가 성공적으로 수정되었습니다.");
+    }
+
+    // 견적 상세 조회
+    @GetMapping("/{requestId}")
+    public CommonResponseEntity<QuotationDetailResponse> getQuotationDetail(
+            @PathVariable Long requestId) {
+        return CommonResponseEntity.success(quotationFacade.getQuotationDetail(requestId));
     }
 }

--- a/app/src/main/java/kr/com/duri/groomer/repository/GroomerRepository.java
+++ b/app/src/main/java/kr/com/duri/groomer/repository/GroomerRepository.java
@@ -8,6 +8,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroomerRepository extends JpaRepository<Groomer, Long> {
     List<Groomer> findByShopId(Long shopId);
-
-    boolean existsByShopId(Long shopId);
 }

--- a/app/src/main/java/kr/com/duri/user/application/dto/response/ApprovedQuotationReqResponse.java
+++ b/app/src/main/java/kr/com/duri/user/application/dto/response/ApprovedQuotationReqResponse.java
@@ -1,5 +1,7 @@
 package kr.com.duri.user.application.dto.response;
 
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,7 +20,7 @@ public class ApprovedQuotationReqResponse {
     private Integer petAge; // 강아지 나이
     private String petBreed; // 견종
     private Boolean petNeutering; // 특이사항1 - 중성화여부
-    private String petCharacter; // 특이사항2 - 성격 정보
-    private String petDiseases; // 특이사항3 - 질환 정보
+    private List<String> petCharacter; // 특이사항2 - 성격 정보
+    private List<String> petDiseases; // 특이사항3 - 질환 정보
     private Integer totalPrice; // 최종 결제 금액 (totalPrice만 추가)
 }

--- a/app/src/main/java/kr/com/duri/user/application/dto/response/NewQuotationReqResponse.java
+++ b/app/src/main/java/kr/com/duri/user/application/dto/response/NewQuotationReqResponse.java
@@ -1,6 +1,7 @@
 package kr.com.duri.user.application.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,7 +21,7 @@ public class NewQuotationReqResponse {
     private Integer petAge; // 강아지 나이
     private String petBreed; // 견종
     private Boolean petNeutering; // 특이사항1 - 중성화여부
-    private String petCharacter; // 특이사항2 - 성격 정보
-    private String petDiseases; // 특이사항3 - 질환 정보
+    private List<String> petCharacter; // 특이사항2 - 성격 정보
+    private List<String> petDiseases; // 특이사항3 - 질환 정보
     private LocalDateTime requestCreatedAt; // 견적 요청 날짜
 }

--- a/app/src/main/java/kr/com/duri/user/application/dto/response/PetDetailResponse.java
+++ b/app/src/main/java/kr/com/duri/user/application/dto/response/PetDetailResponse.java
@@ -1,6 +1,7 @@
 package kr.com.duri.user.application.dto.response;
 
 import java.util.Date;
+import java.util.List;
 
 import kr.com.duri.user.domain.Enum.Gender;
 import lombok.AllArgsConstructor;
@@ -21,7 +22,7 @@ public class PetDetailResponse {
     private String breed; // 견종
     private Integer weight; // 몸무게
     private Boolean neutering; // 중성화 여부
-    private String character; // 성격 정보
-    private String diseases; // 질환 정보
+    private List<String> character; // 성격 정보
+    private List<String> diseases; // 질환 정보
     private Date lastGrooming; // 마지막 미용 일자
 }

--- a/app/src/main/java/kr/com/duri/user/application/mapper/QuotationReqMapper.java
+++ b/app/src/main/java/kr/com/duri/user/application/mapper/QuotationReqMapper.java
@@ -26,7 +26,7 @@ public class QuotationReqMapper {
     }
 
     // JSON 문자열을 List<String>로 변환하는 메서드
-    private String parseJsonArray(String jsonString) {
+    private List<String> parseJsonArray(String jsonString) {
         try {
             // 문자열로 저장된 JSON 배열을 List<String>으로 변환
             List<String> list =
@@ -34,8 +34,7 @@ public class QuotationReqMapper {
                             jsonString,
                             TypeFactory.defaultInstance()
                                     .constructCollectionType(List.class, String.class));
-            // 다시 JSON 형식의 문자열로 변환하여 리턴
-            return objectMapper.writeValueAsString(list);
+            return list;
         } catch (JsonProcessingException e) {
             throw new RuntimeException("JSON 문자열을 리스트로 변환할 수 없습니다.", e);
         }
@@ -129,8 +128,8 @@ public class QuotationReqMapper {
                 .petAge(pet.getAge()) // 강아지 나이
                 .petBreed(pet.getBreed()) // 강아지 견종
                 .petNeutering(pet.getNeutering()) // 특이사항1 - 강아지 중성화 여부
-                .petCharacter(pet.getCharacter()) // 특이사항2 - 강아지 성격 정보
-                .petDiseases(pet.getDiseases()) // 특이사항3 - 강아지 질환 정보
+                .petCharacter(parseJsonArray(pet.getCharacter())) // 강아지 성격 정보
+                .petDiseases(parseJsonArray(pet.getDiseases())) // 강아지 질환 정보
                 .totalPrice(totalPrice)
                 .build();
     }


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- 보낸 견적서 상세 조회 API(DURI-316)

## PR 개요

- https://www.notion.so/API-b9f0a85087d54a4fbb959dd1044e8b28
- 예약확정리스트와 시술완료리스트 빼고 미용사페이지에서 견적 관련 API는 완료했습니다.
- 결제 구현 후 예약확정리스트와 시술완료리스트 API구현을 할 예정입니다.
- 코드 정리가 한번 필요할 것 같습니다. 이후 코드 정리 및 구현 확인을 할 생각입니다.

## Screenshots

<!--
  If capable,
  If there are UI changes, include before and after screenshots.
  This helps reviewers understand the visual impact of the changes.
-->