### PR TITLE
[Feat] 매장 리뷰 간단/상세 리스트 조회 (DURI-294)

### DIFF
--- a/app/src/main/java/kr/com/duri/groomer/application/dto/response/ShopReviewDetailResponse.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/response/ShopReviewDetailResponse.java
@@ -1,0 +1,25 @@
+package kr.com.duri.groomer.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ShopReviewDetailResponse {
+    private Long userId; // 사용자 ID
+    private String userName; // 사용자 이름
+    private String userImageURL; // 사용자 이미지 URL
+    private Long reviewId; // 리뷰 ID
+    private int rating; // 별점
+    private String reviewImageURL; // 리뷰 이미지 URL
+    private String comment; // 리뷰 내용
+    private Long quotationReqId; // 견적 요청서 ID
+    private String menu; // 미용 메뉴
+    private String addMenu; // 추가 미용 메뉴
+    private String specailMenu; // 스페셜 케어
+    private String design; // 디자인 컷
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/response/ShopReviewDetailResponse.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/response/ShopReviewDetailResponse.java
@@ -14,7 +14,7 @@ public class ShopReviewDetailResponse {
     private String userName; // 사용자 이름
     private String userImageURL; // 사용자 이미지 URL
     private Long reviewId; // 리뷰 ID
-    private int rating; // 별점
+    private Integer rating; // 별점
     private String reviewImageURL; // 리뷰 이미지 URL
     private String comment; // 리뷰 내용
     private Long quotationReqId; // 견적 요청서 ID

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/response/ShopReviewResponse.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/response/ShopReviewResponse.java
@@ -1,0 +1,19 @@
+package kr.com.duri.groomer.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ShopReviewResponse {
+    private Long reviewId; // 리뷰 ID
+    private String reviewImageURL; // 리뷰 이미지 URL
+    private String comment; // 리뷰 내용
+    private int rating; // 별점
+    private Long userId; // 고객 ID
+    private String userImageURL; // 고객 이미지 URL
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/response/ShopReviewResponse.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/response/ShopReviewResponse.java
@@ -13,7 +13,7 @@ public class ShopReviewResponse {
     private Long reviewId; // 리뷰 ID
     private String reviewImageURL; // 리뷰 이미지 URL
     private String comment; // 리뷰 내용
-    private int rating; // 별점
+    private Integer rating; // 별점
     private Long userId; // 고객 ID
     private String userImageURL; // 고객 이미지 URL
 }

--- a/app/src/main/java/kr/com/duri/groomer/controller/ShopController.java
+++ b/app/src/main/java/kr/com/duri/groomer/controller/ShopController.java
@@ -6,7 +6,6 @@ import kr.com.duri.common.response.CommonResponseEntity;
 import kr.com.duri.groomer.application.dto.response.MonthIncomeResponse;
 import kr.com.duri.groomer.application.dto.response.ShopDetailResponse;
 import kr.com.duri.groomer.application.dto.response.ShopNearByResponse;
-import kr.com.duri.groomer.application.facade.GroomerHomeFacade;
 import kr.com.duri.groomer.application.facade.ShopFacade;
 import lombok.RequiredArgsConstructor;
 
@@ -22,7 +21,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class ShopController {
 
     private final ShopFacade shopFacade;
-    private final GroomerHomeFacade homeFacade;
 
     // DURI-260 : 매장 상세정보 조회
     @GetMapping("/{shopId}")

--- a/app/src/main/java/kr/com/duri/user/application/dto/request/NewReviewRequest.java
+++ b/app/src/main/java/kr/com/duri/user/application/dto/request/NewReviewRequest.java
@@ -13,6 +13,7 @@ public class NewReviewRequest {
 
     private Long userId; // 로그인한 고객 ID
     private Long shopId; // 리뷰할 매장 ID
+    private Long requestId; // 리뷰를 남길 시술(요청) ID
     private Integer rating; // 별점
     private String comment; // 후기
 }

--- a/app/src/main/java/kr/com/duri/user/application/facade/ReviewFacade.java
+++ b/app/src/main/java/kr/com/duri/user/application/facade/ReviewFacade.java
@@ -1,20 +1,32 @@
 package kr.com.duri.user.application.facade;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+import kr.com.duri.groomer.application.dto.response.ShopReviewDetailResponse;
+import kr.com.duri.groomer.application.dto.response.ShopReviewResponse;
 import kr.com.duri.groomer.application.service.GroomerService;
+import kr.com.duri.groomer.application.service.ShopService;
 import kr.com.duri.groomer.domain.entity.Groomer;
+import kr.com.duri.groomer.domain.entity.Shop;
 import kr.com.duri.user.application.dto.request.NewReviewRequest;
 import kr.com.duri.user.application.dto.request.UpdateReviewRequest;
 import kr.com.duri.user.application.dto.response.ReviewResponse;
 import kr.com.duri.user.application.mapper.ReviewMapper;
 import kr.com.duri.user.application.service.PetService;
+import kr.com.duri.user.application.service.RequestService;
 import kr.com.duri.user.application.service.ReviewImageService;
 import kr.com.duri.user.application.service.ReviewService;
 import kr.com.duri.user.domain.entity.Pet;
+import kr.com.duri.user.domain.entity.QuotationReq;
+import kr.com.duri.user.domain.entity.Request;
 import kr.com.duri.user.domain.entity.Review;
 import kr.com.duri.user.domain.entity.ReviewImage;
+import kr.com.duri.user.domain.entity.SiteUser;
+import kr.com.duri.user.exception.PetNotFoundException;
+import kr.com.duri.user.exception.QuotationReqNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Component;
@@ -28,7 +40,9 @@ public class ReviewFacade {
     private final ReviewService reviewService;
     private final ReviewMapper reviewMapper;
     private final GroomerService groomerService;
+    private final ShopService shopService;
     private final PetService petService;
+    private final RequestService requestService;
 
     // 미용사 조회
     private Groomer getGroomer(Long shopId) {
@@ -40,6 +54,70 @@ public class ReviewFacade {
         return petService.getPetByUserId(userId);
     }
 
+    // 매장 조회
+    private Shop getShop(Long shopId) {
+        return shopService.findById(shopId);
+    }
+
+    // 리뷰로 반려견 조회
+    private Pet getPetByReview(Review review) {
+        return Optional.ofNullable(review.getRequest().getQuotation().getPet())
+                .orElseThrow(() -> new PetNotFoundException("해당 반려견을 찾을 수 없습니다."));
+    }
+
+    // 요청으로 견적 요청서 조회
+    private QuotationReq getQuotationReqByRequest(Request request) {
+        return Optional.ofNullable(request.getQuotation())
+                .orElseThrow(() -> new QuotationReqNotFoundException("해당 견적 요청서를 찾을 수 없습니다."));
+    }
+
+    // 매장 리뷰 리스트 조회
+    public List<ShopReviewResponse> getReviewByShop(Long shopId) {
+        getShop(shopId);
+        // 1. 매장으로 리뷰 조회
+        List<Review> reviewList = reviewService.getReviewsByShopId(shopId);
+        if (reviewList.isEmpty()) { // 해당 리뷰 없음
+            return Collections.emptyList();
+        }
+        return reviewList.stream()
+                .map(
+                        review -> {
+                            // 2. 리뷰로 리뷰 이미지 조회
+                            ReviewImage reviewImage =
+                                    reviewImageService.getReviewImageByReviewId(review.getId());
+                            // 3. 리뷰로 사용자 조회
+                            SiteUser user = getPetByReview(review).getUser();
+                            // 4. DTO 변환
+                            return reviewMapper.toShopReviewResponse(review, reviewImage, user);
+                        })
+                .collect(Collectors.toList());
+    }
+
+    // 매장 리뷰 상세 리스트 조회
+    public List<ShopReviewDetailResponse> getReviewDetailByShop(Long shopId) {
+        List<Review> reviewDetailList = reviewService.getReviewsByShopId(shopId);
+        if (reviewDetailList.isEmpty()) { // 해당 리뷰 없음
+            return Collections.emptyList();
+        }
+        return reviewDetailList.stream()
+                .map(
+                        review -> {
+                            // 2. 리뷰로 리뷰 이미지 조회
+                            ReviewImage reviewImage =
+                                    reviewImageService.getReviewImageByReviewId(review.getId());
+                            // 3. 리뷰로 사용자 조회
+                            SiteUser user = getPetByReview(review).getUser();
+                            // 4. 견적 요청서 조회
+                            QuotationReq quotationReq =
+                                    getQuotationReqByRequest(review.getRequest());
+                            // 5. DTO 변환
+                            return reviewMapper.toShopReviewDetailResponse(
+                                    review, reviewImage, quotationReq, user);
+                        })
+                .collect(Collectors.toList());
+    }
+
+    /* TODO : 리뷰 엔티티 연관 변경에 따른 하단 코드 추후 리팩토링 필요 */
     // [1] 리뷰 목록 조회
     public List<ReviewResponse> getReviewList(Long userId) {
         // 반려견 ID 조회
@@ -55,7 +133,7 @@ public class ReviewFacade {
                         review -> {
                             ReviewImage reviewImage =
                                     reviewImageService.getReviewImageByReviewId(review.getId());
-                            Groomer groomer = getGroomer(review.getShop().getId());
+                            Groomer groomer = getGroomer(review.getRequest().getShop().getId());
                             return reviewMapper.toReviewResponse(groomer, review, reviewImage);
                         })
                 .collect(Collectors.toList());
@@ -70,22 +148,20 @@ public class ReviewFacade {
         }
         // ReviewImage 조회
         ReviewImage reviewImage = reviewImageService.getReviewImageByReviewId(review.getId());
-        Groomer groomer = getGroomer(review.getShop().getId());
+        Groomer groomer = getGroomer(review.getRequest().getShop().getId());
         return reviewMapper.toReviewResponse(groomer, review, reviewImage);
     }
 
     // [3] 리뷰 추가
     public boolean createReview(NewReviewRequest newReviewRequest, MultipartFile img) {
-        // Pet, Groomer 조회
-        Pet pet = getPet(newReviewRequest.getUserId());
-        Groomer groomer = getGroomer(newReviewRequest.getShopId());
         // Review 저장
-        Review review = reviewMapper.toReview(pet, groomer, newReviewRequest);
+        // TODO : Review Entity 수정에 의한 리팩토링 필요
+        Request request = requestService.getRequestById(newReviewRequest.getRequestId());
+        Review review = reviewMapper.toReview(newReviewRequest, request);
         if (review == null) {
             // TODO : 리뷰 저장 안됨
             return false;
         }
-        reviewService.createReview(review);
         // ReviewImage 저장
         reviewImageService.saveReviewImage(img, review);
         return true;

--- a/app/src/main/java/kr/com/duri/user/application/mapper/ReviewMapper.java
+++ b/app/src/main/java/kr/com/duri/user/application/mapper/ReviewMapper.java
@@ -1,41 +1,78 @@
 package kr.com.duri.user.application.mapper;
 
+import kr.com.duri.groomer.application.dto.response.ShopReviewDetailResponse;
+import kr.com.duri.groomer.application.dto.response.ShopReviewResponse;
 import kr.com.duri.groomer.domain.entity.Groomer;
 import kr.com.duri.user.application.dto.request.NewReviewRequest;
 import kr.com.duri.user.application.dto.response.ReviewResponse;
-import kr.com.duri.user.domain.entity.Pet;
+import kr.com.duri.user.domain.entity.QuotationReq;
+import kr.com.duri.user.domain.entity.Request;
 import kr.com.duri.user.domain.entity.Review;
 import kr.com.duri.user.domain.entity.ReviewImage;
+import kr.com.duri.user.domain.entity.SiteUser;
 
 import org.springframework.stereotype.Component;
 
 @Component
 public class ReviewMapper {
 
+    // null 방지
+    private String safeGet(String value) {
+        return value == null ? "" : value;
+    }
+
     // Review Entity to Response DTO
     public ReviewResponse toReviewResponse(
             Groomer groomer, Review review, ReviewImage reviewImage) {
         return ReviewResponse.builder()
                 .reviewId(review.getId())
-                .shopName(groomer.getShop().getName())
-                .groomerName(groomer.getName())
+                .shopName(safeGet(groomer.getShop().getName()))
+                .groomerName(safeGet(groomer.getName()))
                 .rating(review.getRating())
-                .comment(review.getComment())
-                .imgUrl(reviewImage != null ? reviewImage.getImage() : null)
+                .comment(safeGet(review.getComment()))
+                .imgUrl(safeGet(reviewImage.getImage()))
                 .createdAt(review.getCreatedAt())
                 .build();
     }
 
     // Review Request DTO to Entity
-    public Review toReview(Pet pet, Groomer groomer, NewReviewRequest newReviewRequest) {
-        if (groomer == null || pet == null) {
-            throw new IllegalArgumentException("미용사 또는 펫의 정보가 공백입니다.");
-        }
+    public Review toReview(NewReviewRequest newReviewRequest, Request request) {
         return Review.builder()
-                .shop(groomer.getShop())
-                .pet(pet)
                 .rating(newReviewRequest.getRating())
-                .comment(newReviewRequest.getComment())
+                .comment(safeGet(newReviewRequest.getComment()))
+                .request(request)
+                .build();
+    }
+
+    // Review, ReviewImage, SiteUser Entity to ShopReviewResponse DTO
+    public ShopReviewResponse toShopReviewResponse(
+            Review review, ReviewImage reviewImage, SiteUser user) {
+        return ShopReviewResponse.builder()
+                .reviewId(review.getId())
+                .reviewImageURL(safeGet(reviewImage.getImage()))
+                .comment(safeGet(review.getComment()))
+                .rating(review.getRating())
+                .userId(user.getId())
+                .userImageURL(safeGet(user.getImage()))
+                .build();
+    }
+
+    // Review, ReviewImage, SiteUser Entity to ShopReviewDetailResponse DTO
+    public ShopReviewDetailResponse toShopReviewDetailResponse(
+            Review review, ReviewImage reviewImage, QuotationReq quotationReq, SiteUser user) {
+        return ShopReviewDetailResponse.builder()
+                .userId(user.getId())
+                .userName(safeGet(user.getName()))
+                .userImageURL(safeGet(user.getImage()))
+                .reviewId(review.getId())
+                .rating(review.getRating())
+                .comment(safeGet(review.getComment()))
+                .reviewImageURL(safeGet(reviewImage.getImage()))
+                .quotationReqId(quotationReq.getId())
+                .menu(safeGet(quotationReq.getMenu()))
+                .addMenu(safeGet(quotationReq.getAddMenu()))
+                .specailMenu(safeGet(quotationReq.getSpecialMenu()))
+                .design(safeGet(quotationReq.getDesign()))
                 .build();
     }
 }

--- a/app/src/main/java/kr/com/duri/user/application/service/ReviewImageServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/user/application/service/ReviewImageServiceImpl.java
@@ -41,7 +41,7 @@ public class ReviewImageServiceImpl implements ReviewImageService {
     // [1-1] 단일 조회
     @Override
     public ReviewImage getReviewImageByReviewId(Long reviewId) {
-        return getReviewImageList(reviewId).stream().findFirst().orElse(null);
+        return getReviewImageList(reviewId).stream().findFirst().orElse(new ReviewImage());
     }
 
     // [2] 추가, 수정

--- a/app/src/main/java/kr/com/duri/user/application/service/ReviewService.java
+++ b/app/src/main/java/kr/com/duri/user/application/service/ReviewService.java
@@ -7,6 +7,9 @@ import kr.com.duri.user.domain.entity.Review;
 
 public interface ReviewService {
 
+    // 매장 리뷰 조회
+    List<Review> getReviewsByShopId(Long shopId);
+
     // 목록 조회
     List<Review> getReviewList(Long petId);
 

--- a/app/src/main/java/kr/com/duri/user/application/service/ReviewServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/user/application/service/ReviewServiceImpl.java
@@ -16,6 +16,12 @@ public class ReviewServiceImpl implements ReviewService {
 
     private final ReviewRepository reviewRepository;
 
+    // 매장 리뷰 조회
+    @Override
+    public List<Review> getReviewsByShopId(Long shopId) {
+        return reviewRepository.findAllByShopId(shopId);
+    }
+
     // [1] 목록 조회
     @Override
     public List<Review> getReviewList(Long petId) {

--- a/app/src/main/java/kr/com/duri/user/controller/ReviewController.java
+++ b/app/src/main/java/kr/com/duri/user/controller/ReviewController.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import jakarta.validation.Valid;
 import kr.com.duri.common.response.CommonResponseEntity;
+import kr.com.duri.groomer.application.dto.response.ShopReviewDetailResponse;
+import kr.com.duri.groomer.application.dto.response.ShopReviewResponse;
 import kr.com.duri.user.application.dto.request.NewReviewRequest;
 import kr.com.duri.user.application.dto.request.UpdateReviewRequest;
 import kr.com.duri.user.application.dto.response.ReviewResponse;
@@ -27,6 +29,19 @@ import org.springframework.web.multipart.MultipartFile;
 public class ReviewController {
 
     private final ReviewFacade reviewFacade;
+
+    // DURI-294 : 매장 리뷰 리스트 조회
+    @GetMapping("/review/{shopId}")
+    public CommonResponseEntity<List<ShopReviewResponse>> getReviewList(@PathVariable Long shopId) {
+        return CommonResponseEntity.success(reviewFacade.getReviewByShop(shopId));
+    }
+
+    // DURI-324 : 매장 리뷰 상세 리스트 조회
+    @GetMapping("/review-detail/{shopId}")
+    public CommonResponseEntity<List<ShopReviewDetailResponse>> getReviewDetailList(
+            @PathVariable Long shopId) {
+        return CommonResponseEntity.success(reviewFacade.getReviewDetailByShop(shopId));
+    }
 
     // DURI-288 : 리뷰 전체 조회
     @GetMapping("/user/{userId}")

--- a/app/src/main/java/kr/com/duri/user/domain/entity/Review.java
+++ b/app/src/main/java/kr/com/duri/user/domain/entity/Review.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.*;
 import kr.com.duri.common.entity.BaseEntity;
-import kr.com.duri.groomer.domain.entity.Shop;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,13 +22,9 @@ public class Review extends BaseEntity {
     @Column(name = "review_id")
     private Long id; // 리뷰 ID
 
-    @ManyToOne
-    @JoinColumn(name = "shop_id")
-    private Shop shop; // 매장 ID (FK)
-
-    @ManyToOne
-    @JoinColumn(name = "pet_id")
-    private Pet pet; // 반려견 ID (FK)
+    @OneToOne
+    @JoinColumn(name = "request_id")
+    private Request request; // 견적 요청 ID (FK)
 
     @Column(name = "rating")
     private Integer rating; // 별점 (0점~5점)

--- a/app/src/main/java/kr/com/duri/user/repository/ReviewRepository.java
+++ b/app/src/main/java/kr/com/duri/user/repository/ReviewRepository.java
@@ -5,9 +5,29 @@ import java.util.List;
 import kr.com.duri.user.domain.entity.Review;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
+    // 매장 ID 기준 리뷰 찾기
+    @Query(
+            value =
+                    """
+           SELECT rv FROM Review rv
+           JOIN rv.request rq
+           WHERE rq.shop.id = :shopId
+           """)
+    List<Review> findAllByShopId(@Param("shopId") Long shopId);
+
     // 반려견 ID 기준 리뷰 찾기
-    List<Review> findByPetId(Long petId);
+    @Query(
+            value =
+                    """
+            select rv from Review rv
+            join rv.request rq
+            join rq.quotation qr
+            where qr.pet.id = :petId
+            """)
+    List<Review> findByPetId(@Param("petId") Long petId);
 }


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- DURI-294, DURI-324 

## PR 개요

- 기존 리뷰 연관관계 수정
  - (기존) 리뷰 - 매장(Shop), 반려견(Pet) 연결
  - (수정) 리뷰 - 요청(Request) 연결
  - 수정 이유 : 리뷰에서 어떤 시술을 받았는지 확인하기 위해 수정
    - 이로 인해, 기존에 구현했던 리뷰 관련 API들은 차후에 화면 나오고 리팩토링 진행하겠습니다!!
- 매장 리뷰 간단 리스트 조회 구현
- 매장 리뷰 상세 리스트 조회 구현

## Screenshots

- 화면
  - 매장 간단 리스트 조회
![image](https://github.com/user-attachments/assets/40dcce96-53d7-4224-8a68-e60a10fb2bc0)

  - 매장 상세 리스트 조회
![image](https://github.com/user-attachments/assets/40519d6a-682c-4cdb-b2fb-14332b1f1fd0)

- 결과
  - 매장 간단 리스트 조회
![image](https://github.com/user-attachments/assets/d6133129-9f01-4bc8-bb97-b5fa75f430bf)

  - 매장 상세 리스트 조회
![image](https://github.com/user-attachments/assets/caac5101-56ad-4abe-8570-9ac2f8158ada)
 