### PR TITLE
[Fix]결제 후 Quotation상태 변화 변경(DURI-218)

### DIFF
--- a/app/src/main/java/kr/com/duri/groomer/application/service/QuotationService.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/QuotationService.java
@@ -27,4 +27,6 @@ public interface QuotationService {
 
     // QuotationId로 Quotation 조회
     Quotation findById(Long quotationId);
+
+    List<Quotation> findByQuotationReqId(Long quotationReqId);
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/service/impl/QuotationServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/impl/QuotationServiceImpl.java
@@ -24,11 +24,15 @@ public class QuotationServiceImpl implements QuotationService {
     public void saveQuotation(Quotation quotation) {
         boolean existsQuotation =
                 quotationRepository.existsByRequestId(quotation.getRequest().getId());
-        if (existsQuotation) {
+
+        // 존재하는 견적이지만, 동일 ID인 경우 업데이트 허용
+        if (existsQuotation && !quotationRepository.existsById(quotation.getId())) {
             throw new QuotationExistsException("해당 요청 ID에 대한 견적이 이미 존재합니다.");
         }
+
         quotationRepository.save(quotation);
     }
+
 
     @Override
     public Quotation findQuotationById(Long quotationId) {
@@ -82,5 +86,10 @@ public class QuotationServiceImpl implements QuotationService {
         return quotationRepository
                 .findById(quotationId)
                 .orElseThrow(() -> new QuotationNotFoundException("해당 견적을 찾을 수 없습니다."));
+    }
+
+    @Override
+    public List<Quotation> findByQuotationReqId(Long quotationReqId){
+        return quotationRepository.findByRequest_Quotation_Id(quotationReqId);
     }
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/service/impl/QuotationServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/impl/QuotationServiceImpl.java
@@ -33,7 +33,6 @@ public class QuotationServiceImpl implements QuotationService {
         quotationRepository.save(quotation);
     }
 
-
     @Override
     public Quotation findQuotationById(Long quotationId) {
         return quotationRepository
@@ -89,7 +88,7 @@ public class QuotationServiceImpl implements QuotationService {
     }
 
     @Override
-    public List<Quotation> findByQuotationReqId(Long quotationReqId){
+    public List<Quotation> findByQuotationReqId(Long quotationReqId) {
         return quotationRepository.findByRequest_Quotation_Id(quotationReqId);
     }
 }

--- a/app/src/main/java/kr/com/duri/groomer/domain/entity/Quotation.java
+++ b/app/src/main/java/kr/com/duri/groomer/domain/entity/Quotation.java
@@ -61,4 +61,9 @@ public class Quotation extends BaseEntity {
     public void updateComplete(boolean complete) {
         this.complete = complete;
     }
+
+    // 상태 변경 메서드
+    public void updateStatus(QuotationStatus status) {
+        this.status = status;
+    }
 }

--- a/app/src/main/java/kr/com/duri/groomer/repository/QuotationRepository.java
+++ b/app/src/main/java/kr/com/duri/groomer/repository/QuotationRepository.java
@@ -40,7 +40,6 @@ public interface QuotationRepository extends JpaRepository<Quotation, Long> {
     List<Quotation> findTodayQuotation(
             @Param("shopId") Long shopId, @Param("currentTime") LocalDateTime currentTime);
 
-
     // QuotationReq ID로 Quotation 목록 조회
     List<Quotation> findByRequest_Quotation_Id(Long quotationReqId);
 }

--- a/app/src/main/java/kr/com/duri/groomer/repository/QuotationRepository.java
+++ b/app/src/main/java/kr/com/duri/groomer/repository/QuotationRepository.java
@@ -39,4 +39,8 @@ public interface QuotationRepository extends JpaRepository<Quotation, Long> {
           """)
     List<Quotation> findTodayQuotation(
             @Param("shopId") Long shopId, @Param("currentTime") LocalDateTime currentTime);
+
+
+    // QuotationReq ID로 Quotation 목록 조회
+    List<Quotation> findByRequest_Quotation_Id(Long quotationReqId);
 }

--- a/app/src/main/java/kr/com/duri/user/application/facade/PaymentFacade.java
+++ b/app/src/main/java/kr/com/duri/user/application/facade/PaymentFacade.java
@@ -1,5 +1,7 @@
 package kr.com.duri.user.application.facade;
 
+import java.util.List;
+
 import jakarta.servlet.http.HttpSession;
 import kr.com.duri.groomer.application.service.QuotationService;
 import kr.com.duri.groomer.domain.entity.Quotation;
@@ -15,8 +17,6 @@ import lombok.RequiredArgsConstructor;
 import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -50,7 +50,8 @@ public class PaymentFacade {
         Object status = response.get("status");
 
         // Quotation 조회
-        Quotation approvedQuotation = quotationService.findById(confirmPaymentRequest.getQuotationId());
+        Quotation approvedQuotation =
+                quotationService.findById(confirmPaymentRequest.getQuotationId());
 
         // 결제 상태가 DONE일 경우 결제 성공 처리
         if ("DONE".equals(status)) {
@@ -59,16 +60,17 @@ public class PaymentFacade {
             quotationService.saveQuotation(approvedQuotation);
 
             // 동일한 quotationReq에 연결된 다른 Quotation상태 변경
-            List<Quotation> relatedQuotation = quotationService.findByQuotationReqId(
-                    approvedQuotation.getRequest().getQuotation().getId());
+            List<Quotation> relatedQuotation =
+                    quotationService.findByQuotationReqId(
+                            approvedQuotation.getRequest().getQuotation().getId());
 
             relatedQuotation.stream()
                     .filter(q -> !q.getId().equals(approvedQuotation.getId()))
-                    .forEach(q -> {
-                        q.updateStatus(QuotationStatus.EXPIRED);
-                        quotationService.saveQuotation(q);
-                    });
-
+                    .forEach(
+                            q -> {
+                                q.updateStatus(QuotationStatus.EXPIRED);
+                                quotationService.saveQuotation(q);
+                            });
 
             Payment payment = paymentMapper.toPayment(confirmPaymentRequest, approvedQuotation);
             paymentService.save(payment);

--- a/app/src/main/java/kr/com/duri/user/domain/entity/Payment.java
+++ b/app/src/main/java/kr/com/duri/user/domain/entity/Payment.java
@@ -42,7 +42,6 @@ public class Payment extends BaseEntity {
     @Column(name = "price")
     private Integer price; // 최종 결제 금액
 
-    @NotBlank
     @Column(name = "payment_status")
     @Enumerated(EnumType.STRING)
     private PaymentStatus status; // 상태 (대기(WATING), 성공(SUCCESS), 실패(FAILED))

--- a/app/src/main/java/kr/com/duri/user/domain/entity/Payment.java
+++ b/app/src/main/java/kr/com/duri/user/domain/entity/Payment.java
@@ -1,7 +1,6 @@
 package kr.com.duri.user.domain.entity;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
 import kr.com.duri.common.entity.BaseEntity;
 import kr.com.duri.groomer.domain.entity.Quotation;
 import kr.com.duri.user.domain.Enum.PaymentStatus;


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- 결제 후 Quotation상태 변화 변경(DURI-218)

## PR 개요

- 고객이 1번 미용실과 2번 미용실에 quotationReq를 보냄 -> 1번 미용실과 2번미용실에서 견적서를 고객에게 보냄 -> 고객이 1번을 선택해서 결제함 -> 1번 상태는 APPROVED로 2번은 EXPIRED로 상태변화가 됨

## Screenshots
![image](https://github.com/user-attachments/assets/d222ca13-eabd-494e-9a2f-0eb283800164)
