### PR TITLE
[Feat] 고객 온보딩 API 구현 (DURI-258)

### DIFF
--- a/app/src/main/java/kr/com/duri/common/security/jwt/JwtFilter.java
+++ b/app/src/main/java/kr/com/duri/common/security/jwt/JwtFilter.java
@@ -1,7 +1,12 @@
 package kr.com.duri.common.security.jwt;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,15 +14,24 @@ import jakarta.servlet.http.HttpServletResponse;
 import kr.com.duri.common.security.dto.NaverUserDto;
 import kr.com.duri.common.security.provider.NaverOAuth2User;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 // todo : 통합 테스트 진행하며 필요한 부분 리팩토링
+@Component
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
+
+    @Value("${client.user.urls}")
+    private String userUrls;
+
+    @Value("${client.shop.urls}")
+    private String shopUrls;
 
     public JwtFilter(JwtUtil jwtUtil) {
 
@@ -29,53 +43,88 @@ public class JwtFilter extends OncePerRequestFilter {
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        String clientHost = request.getHeader("Host");
-        System.out.println("clientHost: " + clientHost);
+        String origin = request.getHeader("Origin");
+        System.out.println("origin: " + origin);
+        String host = request.getHeader("Host");
+        System.out.println("Host: " + host);
 
-        String userHost = System.getenv("CLIENT_USER_URL"); // 환경 변수에서 가져옴
-        String shopHost = System.getenv("CLIENT_SHOP_URL");
+        // todo : 환경 변수에서 못읽어 오는 부분이 있어 리팩토링 중에 수정하겠습니다.
+        //        List<String> userUrlList = parseUrlsFromEnv(userUrls);
+        //        List<String> shopUrlList = parseUrlsFromEnv(shopUrls);
+        List<String> userUrlList =
+                Arrays.asList("http://localhost:3000", "https://duri-saloncom.vercel.app");
+        List<String> shopUrlList =
+                Arrays.asList("http://localhost:3001", "https://salon-duri-salon.vercel.app");
+
+        System.out.println("userUrls: " + Arrays.toString(userUrlList.toArray()));
+        System.out.println("shopUrls: " + Arrays.toString(shopUrlList.toArray()));
 
         String client = null;
         String token = null;
 
-        // 2. 도메인/호스트 기반으로 클라이언트 추출
-        if (clientHost != null) {
-            if (userHost != null && clientHost.contains(userHost)) {
+        if (origin != null) {
+            if (userUrlList.stream().anyMatch(origin::contains)) {
                 client = "naver_user";
                 token = request.getHeader("authorization_user");
-            } else if (shopHost != null && clientHost.contains(shopHost)) {
+            } else if (shopUrlList.stream().anyMatch(origin::contains)) {
                 client = "naver_shop";
                 token = request.getHeader("authorization_shop");
             }
         }
 
-        // 3. 토큰 및 클라이언트 검증
-        if (token == null || client == null) {
-            System.out.println("Token is missing or client type is undefined");
-            filterChain.doFilter(request, response);
-            return;
+//        client = "naver_user";
+//        token = request.getHeader("authorization_user");
+
+        if (token != null && token.startsWith("Bearer ")) {
+            token = token.substring(7).trim();
         }
 
-        // 4. JWT 만료 확인
-        if (jwtUtil.isExpired(token)) {
-            System.out.println("Token is expired");
-            filterChain.doFilter(request, response);
-            return;
+        System.out.println("client: " + client);
+        System.out.println("token: " + token);
+
+        try {
+            if (token == null || client == null) {
+                System.out.println("Token is missing or client type is undefined");
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            String providerId = jwtUtil.getProviderId(token);
+
+            NaverUserDto naverUserDto =
+                    NaverUserDto.builder().providerId(providerId).client(client).build();
+
+            NaverOAuth2User customOAuth2User = new NaverOAuth2User(naverUserDto);
+
+            Authentication authToken =
+                    new UsernamePasswordAuthenticationToken(
+                            customOAuth2User, null, customOAuth2User.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+        } catch (ExpiredJwtException e) {
+            throw new RuntimeException("Expired JWT token");
+        } catch (UnsupportedJwtException e) {
+            throw new RuntimeException("Unsupported JWT token");
+        } catch (Exception e) {
+            throw new RuntimeException("Unknown error");
         }
 
-        // 5. JWT에서 사용자 정보 추출
-        String providerId = jwtUtil.getProviderId(token);
-
-        NaverUserDto naverUserDto =
-                NaverUserDto.builder().providerId(providerId).client(client).build();
-
-        NaverOAuth2User customOAuth2User = new NaverOAuth2User(naverUserDto);
-
-        Authentication authToken =
-                new UsernamePasswordAuthenticationToken(
-                        customOAuth2User, null, customOAuth2User.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(authToken);
+        //        if (jwtUtil.isExpired(token)) {
+        //            String refreshToken = request.getHeader("refresh_token");
+        //            if (refreshToken == null || !refreshTokenService.validate(refreshToken)) {
+        //                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        //                return;
+        //            }
+        //            String newToken = refreshTokenService.generateNewToken(refreshToken);
+        //            response.setHeader("Authorization", "Bearer " + newToken);
+        //        }
 
         filterChain.doFilter(request, response);
+    }
+
+    private List<String> parseUrlsFromEnv(String envVariable) {
+        if (envVariable == null || envVariable.isBlank()) {
+            return Collections.emptyList();
+        }
+        return List.of(envVariable.split(","));
     }
 }

--- a/app/src/main/java/kr/com/duri/common/security/jwt/JwtFilter.java
+++ b/app/src/main/java/kr/com/duri/common/security/jwt/JwtFilter.java
@@ -72,9 +72,6 @@ public class JwtFilter extends OncePerRequestFilter {
             }
         }
 
-//        client = "naver_user";
-//        token = request.getHeader("authorization_user");
-
         if (token != null && token.startsWith("Bearer ")) {
             token = token.substring(7).trim();
         }
@@ -107,16 +104,6 @@ public class JwtFilter extends OncePerRequestFilter {
         } catch (Exception e) {
             throw new RuntimeException("Unknown error");
         }
-
-        //        if (jwtUtil.isExpired(token)) {
-        //            String refreshToken = request.getHeader("refresh_token");
-        //            if (refreshToken == null || !refreshTokenService.validate(refreshToken)) {
-        //                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        //                return;
-        //            }
-        //            String newToken = refreshTokenService.generateNewToken(refreshToken);
-        //            response.setHeader("Authorization", "Bearer " + newToken);
-        //        }
 
         filterChain.doFilter(request, response);
     }

--- a/app/src/main/java/kr/com/duri/common/security/jwt/JwtUtil.java
+++ b/app/src/main/java/kr/com/duri/common/security/jwt/JwtUtil.java
@@ -52,12 +52,19 @@ public class JwtUtil {
                 .get("providerId", String.class);
     }
 
-    private Long getId(String token) {
+    public Long getId(String token) {
         return Jwts.parser()
                 .verifyWith(secretKey)
                 .build()
                 .parseSignedClaims(token)
                 .getPayload()
                 .get("id", Long.class);
+    }
+
+    public String removeBearer(String token) {
+        if (token.startsWith("Bearer ")) {
+            return token.substring(7);
+        }
+        return token;
     }
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/response/HomeQuotationReqResponse.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/response/HomeQuotationReqResponse.java
@@ -17,7 +17,7 @@ public class HomeQuotationReqResponse {
     private String breed; // 견종
     private String gender; // 성별
     private Integer age; // 나이
-    private Integer weight; // 무게
+    private Float weight; // 무게
     private boolean neutering; // 중성화여부
     private Long quotationReqId; // 견적 요청서 ID
     private String memo; // 요구사항

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/response/RecentProcedureResponse.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/response/RecentProcedureResponse.java
@@ -15,7 +15,7 @@ public class RecentProcedureResponse {
     @Builder.Default private String breed = ""; // 견종
     @Builder.Default private String gender = ""; // 성별
     @Builder.Default private Integer age = 0; // 나이
-    @Builder.Default private Integer weight = 0; // 무게
+    @Builder.Default private Float weight = 0F; // 무게
     @Builder.Default private String memo = ""; // 메모 사항
     @Builder.Default private Long userId = 0L; // 사용자 ID
     @Builder.Default private String userPhone = ""; // 보호자 전화번호

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/response/TodayScheduleResponse.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/response/TodayScheduleResponse.java
@@ -20,6 +20,6 @@ public class TodayScheduleResponse {
     private String petName; // 펫 이름
     private String breed; // 견종
     private String gender; // 성별
-    private Integer weight; // 무게
+    private Float weight; // 무게
     private String groomerName; // 미용사 이름
 }

--- a/app/src/main/java/kr/com/duri/user/application/dto/request/NewPetRequest.java
+++ b/app/src/main/java/kr/com/duri/user/application/dto/request/NewPetRequest.java
@@ -1,0 +1,23 @@
+package kr.com.duri.user.application.dto.request;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class NewPetRequest {
+    private String name;
+    private String breed;
+    private Integer age;
+    private Float weight;
+    private String gender;
+    private Boolean neutering;
+    private List<String> character;
+    private List<String> diseases;
+}

--- a/app/src/main/java/kr/com/duri/user/application/dto/response/PetDetailResponse.java
+++ b/app/src/main/java/kr/com/duri/user/application/dto/response/PetDetailResponse.java
@@ -20,7 +20,7 @@ public class PetDetailResponse {
     private Integer age; // 나이
     private Gender gender; // 성별
     private String breed; // 견종
-    private Integer weight; // 몸무게
+    private Float weight; // 몸무게
     private Boolean neutering; // 중성화 여부
     private List<String> character; // 성격 정보
     private List<String> diseases; // 질환 정보

--- a/app/src/main/java/kr/com/duri/user/application/facade/UserInfoFacade.java
+++ b/app/src/main/java/kr/com/duri/user/application/facade/UserInfoFacade.java
@@ -1,0 +1,38 @@
+package kr.com.duri.user.application.facade;
+
+import kr.com.duri.common.security.jwt.JwtUtil;
+import kr.com.duri.user.application.dto.request.NewPetRequest;
+import kr.com.duri.user.application.dto.response.PetDetailResponse;
+import kr.com.duri.user.application.mapper.PetMapper;
+import kr.com.duri.user.application.service.PetService;
+import kr.com.duri.user.application.service.SiteUserService;
+import kr.com.duri.user.domain.entity.Pet;
+import kr.com.duri.user.domain.entity.SiteUser;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserInfoFacade {
+
+    private final SiteUserService siteUserService;
+
+    private final PetService petService;
+
+    private final PetMapper petMapper;
+
+    private final JwtUtil jwtUtil;
+
+    public PetDetailResponse createNewPet(String token, NewPetRequest newPetRequest) {
+        token = jwtUtil.removeBearer(token);
+
+        Long userId = siteUserService.getUserIdByToken(token);
+
+        SiteUser siteUser = siteUserService.getSiteUserById(userId);
+
+        Pet pet = petService.save(petService.createNewPet(siteUser, newPetRequest));
+
+        return petMapper.toPetResponse(pet);
+    }
+}

--- a/app/src/main/java/kr/com/duri/user/application/facade/UserInfoFacade.java
+++ b/app/src/main/java/kr/com/duri/user/application/facade/UserInfoFacade.java
@@ -1,6 +1,5 @@
 package kr.com.duri.user.application.facade;
 
-import kr.com.duri.common.security.jwt.JwtUtil;
 import kr.com.duri.user.application.dto.request.NewPetRequest;
 import kr.com.duri.user.application.dto.response.PetDetailResponse;
 import kr.com.duri.user.application.mapper.PetMapper;

--- a/app/src/main/java/kr/com/duri/user/application/facade/UserInfoFacade.java
+++ b/app/src/main/java/kr/com/duri/user/application/facade/UserInfoFacade.java
@@ -22,11 +22,7 @@ public class UserInfoFacade {
 
     private final PetMapper petMapper;
 
-    private final JwtUtil jwtUtil;
-
     public PetDetailResponse createNewPet(String token, NewPetRequest newPetRequest) {
-        token = jwtUtil.removeBearer(token);
-
         Long userId = siteUserService.getUserIdByToken(token);
 
         SiteUser siteUser = siteUserService.getSiteUserById(userId);

--- a/app/src/main/java/kr/com/duri/user/application/mapper/PetMapper.java
+++ b/app/src/main/java/kr/com/duri/user/application/mapper/PetMapper.java
@@ -1,0 +1,61 @@
+package kr.com.duri.user.application.mapper;
+
+import java.util.List;
+
+import kr.com.duri.user.application.dto.response.PetDetailResponse;
+import kr.com.duri.user.domain.entity.Pet;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+@Component
+@RequiredArgsConstructor
+public class PetMapper {
+
+    private final ObjectMapper objectMapper;
+
+    private List<String> parseJsonArray(String jsonString) {
+        try {
+            List<String> list =
+                    objectMapper.readValue(
+                            jsonString,
+                            TypeFactory.defaultInstance()
+                                    .constructCollectionType(List.class, String.class));
+            return list;
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("JSON 문자열을 리스트로 변환할 수 없습니다.", e);
+        }
+    }
+
+    private String convertListToJson(List<String> list) {
+        try {
+            return objectMapper.writeValueAsString(list); // 리스트를 JSON 문자열로 변환
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("리스트를 JSON 문자열로 변환하는 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    public PetDetailResponse toPetResponse(Pet pet) {
+        return new PetDetailResponse()
+                .builder()
+                .name(pet.getName())
+                .breed(pet.getBreed())
+                .age(pet.getAge())
+                .weight(pet.getWeight())
+                .gender(pet.getGender())
+                .neutering(pet.getNeutering())
+                .character(parseJsonArray(pet.getCharacter()))
+                .diseases(parseJsonArray(pet.getDiseases()))
+                .image(pet.getImage())
+                .lastGrooming(pet.getLastGrooming())
+                .build();
+    }
+
+    public String toStringJson(List<String> list) {
+        return convertListToJson(list);
+    }
+}

--- a/app/src/main/java/kr/com/duri/user/application/service/PetService.java
+++ b/app/src/main/java/kr/com/duri/user/application/service/PetService.java
@@ -2,7 +2,9 @@ package kr.com.duri.user.application.service;
 
 import java.util.List;
 
+import kr.com.duri.user.application.dto.request.NewPetRequest;
 import kr.com.duri.user.domain.entity.Pet;
+import kr.com.duri.user.domain.entity.SiteUser;
 
 public interface PetService {
 
@@ -14,4 +16,8 @@ public interface PetService {
 
     // petID로 조회
     Pet findById(Long petId);
+
+    Pet createNewPet(SiteUser siteUser, NewPetRequest newPetRequest);
+
+    Pet save(Pet pet);
 }

--- a/app/src/main/java/kr/com/duri/user/application/service/SiteUserService.java
+++ b/app/src/main/java/kr/com/duri/user/application/service/SiteUserService.java
@@ -17,4 +17,8 @@ public interface SiteUserService {
             String birthYear);
 
     String createNewUserJwt(SiteUser siteUser);
+
+    Long getUserIdByToken(String token);
+
+    SiteUser getSiteUserById(Long userId);
 }

--- a/app/src/main/java/kr/com/duri/user/application/service/impl/PetServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/user/application/service/impl/PetServiceImpl.java
@@ -2,8 +2,11 @@ package kr.com.duri.user.application.service.impl;
 
 import java.util.List;
 
+import kr.com.duri.user.application.dto.request.NewPetRequest;
+import kr.com.duri.user.application.mapper.PetMapper;
 import kr.com.duri.user.application.service.PetService;
 import kr.com.duri.user.domain.entity.Pet;
+import kr.com.duri.user.domain.entity.SiteUser;
 import kr.com.duri.user.exception.PetNotFoundException;
 import kr.com.duri.user.repository.PetRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +18,8 @@ import org.springframework.stereotype.Service;
 public class PetServiceImpl implements PetService {
 
     private final PetRepository petRepository;
+
+    private final PetMapper petMapper;
 
     // [1] 목록 조회
     @Override
@@ -36,5 +41,26 @@ public class PetServiceImpl implements PetService {
         return petRepository
                 .findById(petId)
                 .orElseThrow(() -> new PetNotFoundException("애완견 ID를 찾을 수 없습니다."));
+    }
+
+    @Override
+    public Pet createNewPet(SiteUser siteUser, NewPetRequest newPetRequest) {
+        String characterStringJson = petMapper.toStringJson(newPetRequest.getCharacter());
+        String diseasesStringJson = petMapper.toStringJson(newPetRequest.getDiseases());
+        return Pet.createNewPet(
+                siteUser,
+                newPetRequest.getName(),
+                newPetRequest.getBreed(),
+                newPetRequest.getAge(),
+                newPetRequest.getWeight(),
+                newPetRequest.getGender(),
+                newPetRequest.getNeutering(),
+                characterStringJson,
+                diseasesStringJson);
+    }
+
+    @Override
+    public Pet save(Pet pet) {
+        return petRepository.save(pet);
     }
 }

--- a/app/src/main/java/kr/com/duri/user/application/service/impl/SiteUserServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/user/application/service/impl/SiteUserServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import kr.com.duri.common.security.jwt.JwtUtil;
 import kr.com.duri.user.application.service.SiteUserService;
 import kr.com.duri.user.domain.entity.SiteUser;
+import kr.com.duri.user.exception.UserNotFoundException;
 import kr.com.duri.user.repository.SiteUserRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -40,5 +41,17 @@ public class SiteUserServiceImpl implements SiteUserService {
     @Override
     public String createNewUserJwt(SiteUser siteUser) {
         return jwtUtil.createJwt(siteUser.getId(), siteUser.getSocialId(), 60 * 60 * 60 * 60L);
+    }
+
+    @Override
+    public Long getUserIdByToken(String token) {
+        return jwtUtil.getId(token);
+    }
+
+    @Override
+    public SiteUser getSiteUserById(Long userId) {
+        return siteUserRepository
+                .findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
     }
 }

--- a/app/src/main/java/kr/com/duri/user/application/service/impl/SiteUserServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/user/application/service/impl/SiteUserServiceImpl.java
@@ -45,6 +45,7 @@ public class SiteUserServiceImpl implements SiteUserService {
 
     @Override
     public Long getUserIdByToken(String token) {
+        token = jwtUtil.removeBearer(token);
         return jwtUtil.getId(token);
     }
 

--- a/app/src/main/java/kr/com/duri/user/controller/UserInfoController.java
+++ b/app/src/main/java/kr/com/duri/user/controller/UserInfoController.java
@@ -1,0 +1,30 @@
+package kr.com.duri.user.controller;
+
+import kr.com.duri.common.response.CommonResponseEntity;
+import kr.com.duri.user.application.dto.request.NewPetRequest;
+import kr.com.duri.user.application.dto.response.PetDetailResponse;
+import kr.com.duri.user.application.facade.UserInfoFacade;
+import kr.com.duri.user.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user")
+public class UserInfoController {
+
+    private final UserInfoFacade userInfoFacade;
+
+    @PostMapping("/pet") // 헤더에 사용자 정보(고유 소설 아이디, PK)가 있으니 별도의 파라미터는 생략
+    public CommonResponseEntity<PetDetailResponse> getSuccessExample(
+            @RequestHeader("authorization_user") String token,
+            @RequestBody NewPetRequest newPetRequest) {
+        try {
+            return CommonResponseEntity.success(userInfoFacade.createNewPet(token, newPetRequest));
+        } catch (UserNotFoundException e) {
+            return CommonResponseEntity.error(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+        }
+    }
+}

--- a/app/src/main/java/kr/com/duri/user/domain/entity/Pet.java
+++ b/app/src/main/java/kr/com/duri/user/domain/entity/Pet.java
@@ -37,7 +37,7 @@ public class Pet extends BaseEntity {
     private Integer age; // 펫 나이
 
     @Column(name = "pet_weight")
-    private Integer weight; // 펫 몸무게
+    private Float weight; // 펫 몸무게
 
     @Column(name = "pet_gender")
     @Enumerated(EnumType.STRING)

--- a/app/src/main/java/kr/com/duri/user/domain/entity/Pet.java
+++ b/app/src/main/java/kr/com/duri/user/domain/entity/Pet.java
@@ -57,4 +57,27 @@ public class Pet extends BaseEntity {
 
     @Column(name = "last_grooming")
     private Date lastGrooming; // 마지막 미용 일자
+
+    public static Pet createNewPet(
+            SiteUser user,
+            String name,
+            String breed,
+            Integer age,
+            Float weight,
+            String gender,
+            Boolean neutering,
+            String character,
+            String diseases) {
+        return Pet.builder()
+                .user(user)
+                .name(name)
+                .breed(breed)
+                .age(age)
+                .weight(weight)
+                .gender(Gender.valueOf(gender))
+                .neutering(neutering)
+                .character(character)
+                .diseases(diseases)
+                .build();
+    }
 }

--- a/app/src/main/java/kr/com/duri/user/exception/UserNotFoundException.java
+++ b/app/src/main/java/kr/com/duri/user/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package kr.com.duri.user.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- DURI-258

## PR 개요

- 고객 온보딩 API 구현했습니다.
- URL에서 별도의 사용자 아이디 없이 헤더에서 사용자 아이디를 추출하여 수행하도록 구현했습니다.
- JwtFilter에 예외처리를 조금 추가했습니다. (+ 더 보안하도록 하겠습니다.)

## 이슈

- 현재 PetServiceImpl에서 Mapper를 호출해서 사용하는데, 더 좋은 방법이 있을까요? (Json형식을 유지하며 String으로 변환하기 위해 사용)

## Screenshots

<img width="1456" alt="스크린샷 2024-12-06 오후 5 36 14" src="https://github.com/user-attachments/assets/587a0f19-aa83-4b88-b2b2-62463ecf2b84">