### PR TITLE
[Feat] 매장 온보딩 로직 추가 (DURI-260)

### DIFF
--- a/app/src/main/java/kr/com/duri/common/Mapper/CommonMapper.java
+++ b/app/src/main/java/kr/com/duri/common/Mapper/CommonMapper.java
@@ -1,0 +1,47 @@
+package kr.com.duri.common.Mapper;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+@Component
+@RequiredArgsConstructor
+public class CommonMapper {
+
+    private final ObjectMapper objectMapper;
+
+    private List<String> parseJsonArray(String jsonString) {
+        try {
+            List<String> list =
+                    objectMapper.readValue(
+                            jsonString,
+                            TypeFactory.defaultInstance()
+                                    .constructCollectionType(List.class, String.class));
+            return list;
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("JSON 문자열을 리스트로 변환할 수 없습니다.", e);
+        }
+    }
+
+    private String convertListToJson(List<String> list) {
+        try {
+            return objectMapper.writeValueAsString(list); // 리스트를 JSON 문자열로 변환
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("리스트를 JSON 문자열로 변환하는 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    public String toStringJson(List<String> list) {
+        return convertListToJson(list);
+    }
+
+    public List<String> toListString(String jsonString) {
+        return parseJsonArray(jsonString);
+    }
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/request/GroomerDetailRequest.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/request/GroomerDetailRequest.java
@@ -1,0 +1,24 @@
+package kr.com.duri.groomer.application.dto.request;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GroomerDetailRequest {
+    private String email; // 미용사 이메일
+    private String phone; // 미용사 전화번호
+    private String name; // 미용사 이름
+    private String gender; // 미용사 성별
+    private Integer age; // 미용사 나이
+    private Integer history; // 미용사 경력 (월수)
+    private String image; // 프로필 이미지
+    private String info; // 미용사 자기소개
+    private List<String> license; // 자격증
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/request/GroomerOnboardingInfo.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/request/GroomerOnboardingInfo.java
@@ -1,0 +1,21 @@
+package kr.com.duri.groomer.application.dto.request;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GroomerOnboardingInfo {
+    private String name;
+    private String profileImage;
+    private String gender;
+    private Integer age;
+    private Integer history; // 미용사 경력 (월수)
+    private List<String> license;
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/request/ShopDetailRequest.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/request/ShopDetailRequest.java
@@ -20,10 +20,10 @@ public class ShopDetailRequest {
     private Double lat; // 매장 위도
     private Double lon; // 매장 경도
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
     private LocalTime openTime; // 오픈 시간
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
     private LocalTime closeTime; // 마감 시간
 
     private String info; // 매장 소개

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/request/ShopDetailRequest.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/request/ShopDetailRequest.java
@@ -1,0 +1,31 @@
+package kr.com.duri.groomer.application.dto.request;
+
+import java.time.LocalTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ShopDetailRequest {
+    private String name; // 매장 이름
+    private String phone; // 매장 전화번호
+    private String address; // 매장 주소
+    private Double lat; // 매장 위도
+    private Double lon; // 매장 경도
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+    private LocalTime openTime; // 오픈 시간
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+    private LocalTime closeTime; // 마감 시간
+
+    private String info; // 매장 소개
+    private String kakaoTalk; // 오픈채팅 링크
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/request/ShopOnboardingInfo.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/request/ShopOnboardingInfo.java
@@ -1,0 +1,20 @@
+package kr.com.duri.groomer.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ShopOnboardingInfo {
+    private String name;
+    private String phone;
+    private String address; // 매장 주소
+    private Double lat; // 매장 위도
+    private Double lon; // 매장 경도
+    private String businessRegistrationNumber; // 사업자 등록번호
+    private String groomerLicenseNumber; // 미용사 면허번호
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/request/ShopOnboardingRequest.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/request/ShopOnboardingRequest.java
@@ -1,0 +1,15 @@
+package kr.com.duri.groomer.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ShopOnboardingRequest {
+    private ShopDetailRequest shopDetailRequest;
+    private GroomerDetailRequest groomerDetailRequest;
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/request/ShopOnboardingRequest.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/request/ShopOnboardingRequest.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class ShopOnboardingRequest {
-    private ShopDetailRequest shopDetailRequest;
-    private GroomerDetailRequest groomerDetailRequest;
+    private ShopOnboardingInfo shopOnboardingInfo;
+    private GroomerOnboardingInfo groomerOnboardingInfo;
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/response/NewShopJwtResponse.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/response/NewShopJwtResponse.java
@@ -9,4 +9,5 @@ public class NewShopJwtResponse {
     private String client;
     private String token;
     private Boolean newUser;
+    private String entry;
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/response/ShopOnboardingResponse.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/response/ShopOnboardingResponse.java
@@ -1,0 +1,15 @@
+package kr.com.duri.groomer.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ShopOnboardingResponse {
+    private ShopDetailResponse shopDetailResponse;
+    private GroomerDetailResponse groomerDetailResponse;
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/facade/ShopOnboardingFacade.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/facade/ShopOnboardingFacade.java
@@ -30,11 +30,11 @@ public class ShopOnboardingFacade {
 
         Shop shop = shopService.findById(shopId);
 
-        shop = shopService.updateDetail(shop, shopOnboardingRequest.getShopDetailRequest());
+        shop = shopService.updateDetail(shop, shopOnboardingRequest.getShopOnboardingInfo());
 
         Groomer groomer =
                 groomerService.createNewGroomer(
-                        shop, shopOnboardingRequest.getGroomerDetailRequest());
+                        shop, shopOnboardingRequest.getGroomerOnboardingInfo());
 
         return ShopOnboardingResponse.builder()
                 .shopDetailResponse(shopMapper.toShopDetailResponse(shop))

--- a/app/src/main/java/kr/com/duri/groomer/application/facade/ShopOnboardingFacade.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/facade/ShopOnboardingFacade.java
@@ -1,0 +1,44 @@
+package kr.com.duri.groomer.application.facade;
+
+import kr.com.duri.groomer.application.dto.request.ShopOnboardingRequest;
+import kr.com.duri.groomer.application.dto.response.ShopOnboardingResponse;
+import kr.com.duri.groomer.application.mapper.GroomerMapper;
+import kr.com.duri.groomer.application.mapper.ShopMapper;
+import kr.com.duri.groomer.application.service.GroomerService;
+import kr.com.duri.groomer.application.service.ShopService;
+import kr.com.duri.groomer.domain.entity.Groomer;
+import kr.com.duri.groomer.domain.entity.Shop;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ShopOnboardingFacade {
+
+    private final ShopService shopService;
+
+    private final GroomerService groomerService;
+
+    private final ShopMapper shopMapper;
+
+    private final GroomerMapper groomerMapper;
+
+    public ShopOnboardingResponse shopAndGroomerOnboarding(
+            String token, ShopOnboardingRequest shopOnboardingRequest) {
+        Long shopId = shopService.getShopIdByToken(token);
+
+        Shop shop = shopService.findById(shopId);
+
+        shop = shopService.updateDetail(shop, shopOnboardingRequest.getShopDetailRequest());
+
+        Groomer groomer =
+                groomerService.createNewGroomer(
+                        shop, shopOnboardingRequest.getGroomerDetailRequest());
+
+        return ShopOnboardingResponse.builder()
+                .shopDetailResponse(shopMapper.toShopDetailResponse(shop))
+                .groomerDetailResponse(groomerMapper.toGroomerDetailResponse(groomer))
+                .build();
+    }
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/mapper/GroomerMapper.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/mapper/GroomerMapper.java
@@ -1,0 +1,21 @@
+package kr.com.duri.groomer.application.mapper;
+
+import kr.com.duri.groomer.application.dto.response.GroomerDetailResponse;
+import kr.com.duri.groomer.domain.entity.Groomer;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GroomerMapper {
+
+    public GroomerDetailResponse toGroomerDetailResponse(Groomer groomer) {
+        return GroomerDetailResponse.builder()
+                .image(groomer.getImage()) // 미용사 이미지
+                .name(groomer.getName()) // 미용사 이름
+                .history(groomer.getHistory()) // 미용사 경력
+                .info(groomer.getInfo()) // 미용사 자기소개
+                .build();
+    }
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/mapper/ShopJwtMapper.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/mapper/ShopJwtMapper.java
@@ -13,6 +13,7 @@ public class ShopJwtMapper {
                 .token(token)
                 .client("authorization_shop")
                 .newUser(shop.getNewShop())
+                .entry(shop.getEntry())
                 .build();
     }
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/mapper/ShopMapper.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/mapper/ShopMapper.java
@@ -27,6 +27,16 @@ public class ShopMapper {
                 .build();
     }
 
+    public ShopDetailResponse toShopDetailResponse(Shop shop) {
+        return ShopDetailResponse.builder()
+                .id(shop.getId())
+                .name(shop.getName())
+                .address(shop.getAddress())
+                .imageURL(null)
+                .phone(shop.getPhone())
+                .build();
+    }
+
     public ShopNearByResponse toShopNearByResponse(
             Long shopId,
             String shopName,

--- a/app/src/main/java/kr/com/duri/groomer/application/service/GroomerService.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/GroomerService.java
@@ -1,11 +1,11 @@
 package kr.com.duri.groomer.application.service;
 
-import kr.com.duri.groomer.application.dto.request.GroomerDetailRequest;
+import kr.com.duri.groomer.application.dto.request.GroomerOnboardingInfo;
 import kr.com.duri.groomer.domain.entity.Groomer;
 import kr.com.duri.groomer.domain.entity.Shop;
 
 public interface GroomerService {
     Groomer getGroomerByShopId(Long shopId);
 
-    Groomer createNewGroomer(Shop shop, GroomerDetailRequest groomerDetailRequest);
+    Groomer createNewGroomer(Shop shop, GroomerOnboardingInfo groomerOnboardingInfo);
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/service/GroomerService.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/GroomerService.java
@@ -1,7 +1,11 @@
 package kr.com.duri.groomer.application.service;
 
+import kr.com.duri.groomer.application.dto.request.GroomerDetailRequest;
 import kr.com.duri.groomer.domain.entity.Groomer;
+import kr.com.duri.groomer.domain.entity.Shop;
 
 public interface GroomerService {
     Groomer getGroomerByShopId(Long shopId);
+
+    Groomer createNewGroomer(Shop shop, GroomerDetailRequest groomerDetailRequest);
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/service/ShopService.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/ShopService.java
@@ -3,7 +3,7 @@ package kr.com.duri.groomer.application.service;
 import java.util.List;
 import java.util.Optional;
 
-import kr.com.duri.groomer.application.dto.request.ShopDetailRequest;
+import kr.com.duri.groomer.application.dto.request.ShopOnboardingInfo;
 import kr.com.duri.groomer.domain.entity.Shop;
 
 public interface ShopService {
@@ -23,5 +23,5 @@ public interface ShopService {
 
     Long getShopIdByToken(String token);
 
-    Shop updateDetail(Shop shop, ShopDetailRequest shopDetailRequest);
+    Shop updateDetail(Shop shop, ShopOnboardingInfo shopOnboardingInfo);
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/service/ShopService.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/ShopService.java
@@ -21,11 +21,9 @@ public interface ShopService {
 
     List<Object[]> findShopsWithSearch(String search, Double lat, Double lon);
 
-
     Long getShopIdByToken(String token);
 
     Shop updateDetail(Shop shop, ShopOnboardingInfo shopOnboardingInfo);
 
     Shop updateShopRating(Long shopId, Float rating);
-
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/service/ShopService.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/ShopService.java
@@ -3,6 +3,7 @@ package kr.com.duri.groomer.application.service;
 import java.util.List;
 import java.util.Optional;
 
+import kr.com.duri.groomer.application.dto.request.ShopDetailRequest;
 import kr.com.duri.groomer.domain.entity.Shop;
 
 public interface ShopService {
@@ -19,4 +20,8 @@ public interface ShopService {
     List<Object[]> findShopsWithinRadius(Double lat, Double lon, Double radius);
 
     List<Object[]> findShopsWithSearch(String search, Double lat, Double lon);
+
+    Long getShopIdByToken(String token);
+
+    Shop updateDetail(Shop shop, ShopDetailRequest shopDetailRequest);
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/service/impl/GroomerServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/impl/GroomerServiceImpl.java
@@ -1,7 +1,10 @@
 package kr.com.duri.groomer.application.service.impl;
 
+import kr.com.duri.common.Mapper.CommonMapper;
+import kr.com.duri.groomer.application.dto.request.GroomerDetailRequest;
 import kr.com.duri.groomer.application.service.GroomerService;
 import kr.com.duri.groomer.domain.entity.Groomer;
+import kr.com.duri.groomer.domain.entity.Shop;
 import kr.com.duri.groomer.exception.GroomerNotFoundException;
 import kr.com.duri.groomer.repository.GroomerRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,10 +17,29 @@ public class GroomerServiceImpl implements GroomerService {
 
     private final GroomerRepository groomerRepository;
 
+    private final CommonMapper commonMapper;
+
     @Override
     public Groomer getGroomerByShopId(Long shopId) {
         return groomerRepository.findByShopId(shopId).stream()
                 .findFirst()
                 .orElseThrow(() -> new GroomerNotFoundException("해당 매장의 미용사를 찾을 수 없습니다."));
+    }
+
+    @Override
+    public Groomer createNewGroomer(Shop shop, GroomerDetailRequest groomerDetailRequest) {
+        String licenseStringJson = commonMapper.toStringJson(groomerDetailRequest.getLicense());
+        return groomerRepository.save(
+                Groomer.createNewGroomer(
+                        shop,
+                        groomerDetailRequest.getEmail(),
+                        groomerDetailRequest.getPhone(),
+                        groomerDetailRequest.getName(),
+                        groomerDetailRequest.getAge(),
+                        groomerDetailRequest.getGender(),
+                        groomerDetailRequest.getHistory(),
+                        groomerDetailRequest.getImage(),
+                        groomerDetailRequest.getInfo(),
+                        licenseStringJson));
     }
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/service/impl/GroomerServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/impl/GroomerServiceImpl.java
@@ -1,7 +1,7 @@
 package kr.com.duri.groomer.application.service.impl;
 
 import kr.com.duri.common.Mapper.CommonMapper;
-import kr.com.duri.groomer.application.dto.request.GroomerDetailRequest;
+import kr.com.duri.groomer.application.dto.request.GroomerOnboardingInfo;
 import kr.com.duri.groomer.application.service.GroomerService;
 import kr.com.duri.groomer.domain.entity.Groomer;
 import kr.com.duri.groomer.domain.entity.Shop;
@@ -27,19 +27,16 @@ public class GroomerServiceImpl implements GroomerService {
     }
 
     @Override
-    public Groomer createNewGroomer(Shop shop, GroomerDetailRequest groomerDetailRequest) {
-        String licenseStringJson = commonMapper.toStringJson(groomerDetailRequest.getLicense());
+    public Groomer createNewGroomer(Shop shop, GroomerOnboardingInfo groomerOnboardingInfo) {
+        String licenseStringJson = commonMapper.toStringJson(groomerOnboardingInfo.getLicense());
         return groomerRepository.save(
-                Groomer.createNewGroomer(
+                Groomer.createNewGroomerWithOnboarding(
                         shop,
-                        groomerDetailRequest.getEmail(),
-                        groomerDetailRequest.getPhone(),
-                        groomerDetailRequest.getName(),
-                        groomerDetailRequest.getAge(),
-                        groomerDetailRequest.getGender(),
-                        groomerDetailRequest.getHistory(),
-                        groomerDetailRequest.getImage(),
-                        groomerDetailRequest.getInfo(),
+                        groomerOnboardingInfo.getName(),
+                        groomerOnboardingInfo.getAge(),
+                        groomerOnboardingInfo.getGender(),
+                        groomerOnboardingInfo.getHistory(),
+                        groomerOnboardingInfo.getProfileImage(),
                         licenseStringJson));
     }
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/service/impl/ShopServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/impl/ShopServiceImpl.java
@@ -59,7 +59,6 @@ public class ShopServiceImpl implements ShopService {
         return shopRepository.findShopsWithSearch(search, lat, lon);
     }
 
-
     @Override
     public Long getShopIdByToken(String token) {
         token = jwtUtil.removeBearer(token);

--- a/app/src/main/java/kr/com/duri/groomer/application/service/impl/ShopServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/impl/ShopServiceImpl.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import kr.com.duri.common.security.jwt.JwtUtil;
-import kr.com.duri.groomer.application.dto.request.ShopDetailRequest;
+import kr.com.duri.groomer.application.dto.request.ShopOnboardingInfo;
 import kr.com.duri.groomer.application.service.ShopService;
 import kr.com.duri.groomer.domain.entity.Shop;
 import kr.com.duri.groomer.exception.ShopNotFoundException;
@@ -66,17 +66,15 @@ public class ShopServiceImpl implements ShopService {
     }
 
     @Override
-    public Shop updateDetail(Shop shop, ShopDetailRequest shopDetailRequest) {
+    public Shop updateDetail(Shop shop, ShopOnboardingInfo shopOnboardingInfo) {
         return shopRepository.save(
-                shop.updateDetail(
-                        shopDetailRequest.getName(),
-                        shopDetailRequest.getPhone(),
-                        shopDetailRequest.getAddress(),
-                        shopDetailRequest.getLat(),
-                        shopDetailRequest.getLon(),
-                        shopDetailRequest.getOpenTime(),
-                        shopDetailRequest.getCloseTime(),
-                        shopDetailRequest.getInfo(),
-                        shopDetailRequest.getKakaoTalk()));
+                shop.updateDetailWithOnboarding(
+                        shopOnboardingInfo.getName(),
+                        shopOnboardingInfo.getPhone(),
+                        shopOnboardingInfo.getAddress(),
+                        shopOnboardingInfo.getLat(),
+                        shopOnboardingInfo.getLon(),
+                        shopOnboardingInfo.getBusinessRegistrationNumber(),
+                        shopOnboardingInfo.getGroomerLicenseNumber()));
     }
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/service/impl/ShopServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/impl/ShopServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import kr.com.duri.common.security.jwt.JwtUtil;
+import kr.com.duri.groomer.application.dto.request.ShopDetailRequest;
 import kr.com.duri.groomer.application.service.ShopService;
 import kr.com.duri.groomer.domain.entity.Shop;
 import kr.com.duri.groomer.exception.ShopNotFoundException;
@@ -56,5 +57,26 @@ public class ShopServiceImpl implements ShopService {
     @Override
     public List<Object[]> findShopsWithSearch(String search, Double lat, Double lon) {
         return shopRepository.findShopsWithSearch(search, lat, lon);
+    }
+
+    @Override
+    public Long getShopIdByToken(String token) {
+        token = jwtUtil.removeBearer(token);
+        return jwtUtil.getId(token);
+    }
+
+    @Override
+    public Shop updateDetail(Shop shop, ShopDetailRequest shopDetailRequest) {
+        return shopRepository.save(
+                shop.updateDetail(
+                        shopDetailRequest.getName(),
+                        shopDetailRequest.getPhone(),
+                        shopDetailRequest.getAddress(),
+                        shopDetailRequest.getLat(),
+                        shopDetailRequest.getLon(),
+                        shopDetailRequest.getOpenTime(),
+                        shopDetailRequest.getCloseTime(),
+                        shopDetailRequest.getInfo(),
+                        shopDetailRequest.getKakaoTalk()));
     }
 }

--- a/app/src/main/java/kr/com/duri/groomer/controller/ShopOnboardingController.java
+++ b/app/src/main/java/kr/com/duri/groomer/controller/ShopOnboardingController.java
@@ -1,0 +1,30 @@
+package kr.com.duri.groomer.controller;
+
+import kr.com.duri.common.response.CommonResponseEntity;
+import kr.com.duri.groomer.application.dto.request.ShopOnboardingRequest;
+import kr.com.duri.groomer.application.dto.response.ShopOnboardingResponse;
+import kr.com.duri.groomer.application.facade.ShopOnboardingFacade;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/shop")
+public class ShopOnboardingController {
+
+    private final ShopOnboardingFacade shopOnboardingFacade;
+
+    @PostMapping("/onboarding")
+    public CommonResponseEntity<ShopOnboardingResponse> shopAndGroomerOnboarding(
+            @RequestHeader("authorization_shop") String token,
+            @RequestBody ShopOnboardingRequest shopOnboardingRequest) {
+        try {
+            return CommonResponseEntity.success(
+                    shopOnboardingFacade.shopAndGroomerOnboarding(token, shopOnboardingRequest));
+        } catch (Exception e) {
+            return CommonResponseEntity.error(HttpStatus.BAD_REQUEST, "매장, 미용사 등록에 실패했습니다.");
+        }
+    }
+}

--- a/app/src/main/java/kr/com/duri/groomer/domain/Enum/Gender.java
+++ b/app/src/main/java/kr/com/duri/groomer/domain/Enum/Gender.java
@@ -1,0 +1,6 @@
+package kr.com.duri.groomer.domain.Enum;
+
+public enum Gender {
+    M,
+    F
+}

--- a/app/src/main/java/kr/com/duri/groomer/domain/entity/Groomer.java
+++ b/app/src/main/java/kr/com/duri/groomer/domain/entity/Groomer.java
@@ -53,27 +53,21 @@ public class Groomer extends BaseEntity {
     @Column(name = "groomer_license")
     private String license; // 자격증
 
-    public static Groomer createNewGroomer(
+    public static Groomer createNewGroomerWithOnboarding(
             Shop shop,
-            String email,
-            String phone,
             String name,
             Integer age,
             String gender,
             Integer history,
-            String image,
-            String info,
+            String profileImage,
             String license) {
         return Groomer.builder()
                 .shop(shop)
-                .email(email)
-                .phone(phone)
                 .name(name)
                 .age(age)
                 .gender(Gender.valueOf(gender))
                 .history(history)
-                .image(image)
-                .info(info)
+                .image(profileImage)
                 .license(license)
                 .build();
     }

--- a/app/src/main/java/kr/com/duri/groomer/domain/entity/Groomer.java
+++ b/app/src/main/java/kr/com/duri/groomer/domain/entity/Groomer.java
@@ -2,6 +2,7 @@ package kr.com.duri.groomer.domain.entity;
 
 import jakarta.persistence.*;
 import kr.com.duri.common.entity.BaseEntity;
+import kr.com.duri.groomer.domain.Enum.Gender;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,12 +34,47 @@ public class Groomer extends BaseEntity {
     @Column(name = "groomer_name")
     private String name; // 미용사 이름
 
+    @Column(name = "groomer_age")
+    private Integer age; // 미용사 나이
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "groomer_gender")
+    private Gender gender; // 미용사 성별
+
     @Column(name = "groomer_history")
-    private Integer history; // 미용사 경력 (년수)
+    private Integer history; // 미용사 경력 (월수)
 
     @Column(name = "groomer_image")
     private String image; // 프로필 이미지
 
     @Column(name = "groomer_info", columnDefinition = "TEXT")
     private String info; // 미용사 자기소개
+
+    @Column(name = "groomer_license")
+    private String license; // 자격증
+
+    public static Groomer createNewGroomer(
+            Shop shop,
+            String email,
+            String phone,
+            String name,
+            Integer age,
+            String gender,
+            Integer history,
+            String image,
+            String info,
+            String license) {
+        return Groomer.builder()
+                .shop(shop)
+                .email(email)
+                .phone(phone)
+                .name(name)
+                .age(age)
+                .gender(Gender.valueOf(gender))
+                .history(history)
+                .image(image)
+                .info(info)
+                .license(license)
+                .build();
+    }
 }

--- a/app/src/main/java/kr/com/duri/groomer/domain/entity/Shop.java
+++ b/app/src/main/java/kr/com/duri/groomer/domain/entity/Shop.java
@@ -79,4 +79,27 @@ public class Shop extends BaseEntity {
 
         return Shop.builder().socialId(socialId).email(email).build();
     }
+
+    public Shop updateDetail(
+            String name,
+            String phone,
+            String address,
+            Double lat,
+            Double lon,
+            LocalTime openTime,
+            LocalTime closeTime,
+            String info,
+            String kakaoTalk) {
+        this.name = name;
+        this.phone = phone;
+        this.address = address;
+        this.lat = lat;
+        this.lon = lon;
+        this.openTime = openTime;
+        this.closeTime = closeTime;
+        this.info = info;
+        this.kakaoTalk = kakaoTalk;
+        this.newShop = false;
+        return this;
+    }
 }

--- a/app/src/main/java/kr/com/duri/groomer/domain/entity/Shop.java
+++ b/app/src/main/java/kr/com/duri/groomer/domain/entity/Shop.java
@@ -72,34 +72,39 @@ public class Shop extends BaseEntity {
     @Column(name = "shop_provider")
     private String provider = "Naver"; // 제공자
 
+    @Column(name = "shop_business_registration_number")
+    private String businessRegistrationNumber; // 사업자 등록번호
+
+    @Column(name = "shop_groomer_license_number")
+    private String groomerLicenseNumber; // 미용사 면허번호
+
     public static Shop createNewShop(String socialId, String email) {
         if (socialId == null || socialId.isEmpty()) {
             throw new IllegalArgumentException("Social ID must not be null or empty");
         }
 
-        return Shop.builder().socialId(socialId).email(email).build();
+        return Shop.builder().socialId(socialId).email(email).entry("W").build();
     }
 
-    public Shop updateDetail(
+    public Shop updateDetailWithOnboarding(
             String name,
             String phone,
             String address,
             Double lat,
             Double lon,
-            LocalTime openTime,
-            LocalTime closeTime,
-            String info,
-            String kakaoTalk) {
+            String businessRegistrationNumber,
+            String groomerLicenseNumber) {
         this.name = name;
         this.phone = phone;
         this.address = address;
         this.lat = lat;
         this.lon = lon;
-        this.openTime = openTime;
-        this.closeTime = closeTime;
-        this.info = info;
-        this.kakaoTalk = kakaoTalk;
+        this.businessRegistrationNumber = businessRegistrationNumber;
+        this.groomerLicenseNumber = groomerLicenseNumber;
         this.newShop = false;
+        this.adtop = false;
+        this.entry = "W";
+        this.rating = 0.0f;
         return this;
     }
 }


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- DURI-260

## PR 개요

- 엔티티에 일부 데이터가 추가 됐습니다. (매장 사업자 번호, 미용사 자격증 번호, 미용사 성별, 미용사 나이 등)
- 매장, 미용사 온보딩 로직 추가했습니다.
- 매장 토큰 발급 api 호출시 승인된 가게인지 확인하는 값을 추가로 전송하도록 추가했습니다.
- `DetailRequest`와 `OnboardingInfo`를 하나로 가져가서 코드를 재사용 하려해봤으나, 최초에 등록하고 이후에 변경 못하는 정보도 있고, 두개의 형태가 조금은 달라질 부분이 생길거 같아 분리했습니다. `DetailRequest`는 프로필 수정 부분에서 활용하겠습니다.

## Screenshots

<img width="1710" alt="스크린샷 2024-12-10 오전 2 03 35" src="https://github.com/user-attachments/assets/99ab5246-b52a-4ace-b77e-609504442c82">
