### PR TITLE
[Refactor] userId와 shopId - 헤더에서 꺼내올 수 있도록 전체 코드 수정 (DURI-ETC)

### DIFF
--- a/app/src/main/java/kr/com/duri/groomer/application/facade/GroomerHomeFacade.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/facade/GroomerHomeFacade.java
@@ -65,7 +65,8 @@ public class GroomerHomeFacade {
     }
 
     // 가까운 시술정보 조회
-    public RecentProcedureResponse getRecentProcedure(Long shopId) {
+    public RecentProcedureResponse getRecentProcedure(String token) {
+        Long shopId = shopService.getShopIdByToken(token);
         getShop(shopId);
         // 1. 현재 일자로부터 가장 최근의 견적서 조회
         Quotation quotation = quotationService.getClosetQuoationByShopId(shopId);
@@ -84,7 +85,8 @@ public class GroomerHomeFacade {
     }
 
     // 당일 스케줄 조회
-    public List<TodayScheduleResponse> getTodaySchedule(Long shopId) {
+    public List<TodayScheduleResponse> getTodaySchedule(String token) {
+        Long shopId = shopService.getShopIdByToken(token);
         getShop(shopId);
         // 1. 매장으로 디자이너 조회
         Groomer groomer = groomerService.getGroomerByShopId(shopId);
@@ -126,7 +128,8 @@ public class GroomerHomeFacade {
     }
 
     // 받은 견적요청서 리스트 조회
-    public List<HomeQuotationReqResponse> getRequestList(Long shopId) {
+    public List<HomeQuotationReqResponse> getRequestList(String token) {
+        Long shopId = shopService.getShopIdByToken(token);
         getShop(shopId);
         // 1. 매장으로 받은 미승인 요청 리스트 조회
         List<Request> requestList = requestService.getNewRequestsByShopId(shopId);

--- a/app/src/main/java/kr/com/duri/groomer/application/facade/ShopFacade.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/facade/ShopFacade.java
@@ -33,7 +33,8 @@ public class ShopFacade {
     }
 
     // 매장 상세정보 조회
-    public ShopDetailResponse getShopDetail(Long shopId) {
+    public ShopDetailResponse getShopDetail(String token) {
+        Long shopId = shopService.getShopIdByToken(token);
         Shop shop = getShop(shopId);
         // TODO : 매장 이미지 조회 구현 및 연결
         ShopImage shopImage = new ShopImage(); // shopImageService.?(shopId)
@@ -79,7 +80,8 @@ public class ShopFacade {
     }
 
     // 총 매출 통계 조회
-    public MonthIncomeResponse getMonthIncome(Long shopId) {
+    public MonthIncomeResponse getMonthIncome(String token) {
+        Long shopId = shopService.getShopIdByToken(token);
         getShop(shopId);
         Long totalIncome = paymentService.getTotalPriceMonth(shopId);
         return shopMapper.toShopDetailResponse(totalIncome);

--- a/app/src/main/java/kr/com/duri/groomer/application/service/ShopService.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/ShopService.java
@@ -25,4 +25,7 @@ public interface ShopService {
 
     // 반경 내 매장 목록 조회
     List<Shop> findShopsByRadius(Double lat, Double lon, Double radians);
+
+    // 토큰으로 매장 아이디 찾기
+    Long getShopIdByToken(String token);
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/service/ShopService.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/ShopService.java
@@ -21,8 +21,6 @@ public interface ShopService {
 
     List<Object[]> findShopsWithSearch(String search, Double lat, Double lon);
 
-    Long getShopIdByToken(String token);
-
     Shop updateDetail(Shop shop, ShopOnboardingInfo shopOnboardingInfo);
 
     Shop updateShopRating(Long shopId, Float rating);

--- a/app/src/main/java/kr/com/duri/groomer/application/service/impl/ShopServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/impl/ShopServiceImpl.java
@@ -60,12 +60,6 @@ public class ShopServiceImpl implements ShopService {
     }
 
     @Override
-    public Long getShopIdByToken(String token) {
-        token = jwtUtil.removeBearer(token);
-        return jwtUtil.getId(token);
-    }
-
-    @Override
     public Shop updateDetail(Shop shop, ShopOnboardingInfo shopOnboardingInfo) {
         return shopRepository.save(
                 shop.updateDetailWithOnboarding(

--- a/app/src/main/java/kr/com/duri/groomer/application/service/impl/ShopServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/impl/ShopServiceImpl.java
@@ -71,4 +71,11 @@ public class ShopServiceImpl implements ShopService {
     public List<Shop> findShopsByRadius(Double lat, Double lon, Double radians) {
         return shopRepository.findShopsByRadius(lat, lon, radians);
     }
+
+    // 토큰으로 매장 아이디 찾기
+    @Override
+    public Long getShopIdByToken(String token) {
+        token = jwtUtil.removeBearer(token);
+        return jwtUtil.getId(token);
+    }
 }

--- a/app/src/main/java/kr/com/duri/groomer/controller/GroomerHomeController.java
+++ b/app/src/main/java/kr/com/duri/groomer/controller/GroomerHomeController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,17 +26,17 @@ public class GroomerHomeController {
     private final GroomerHomeFacade homeFacade;
 
     // DURI-221 : 가까운 시술정보 조회
-    @GetMapping("/closet/{shopId}")
+    @GetMapping("/closet")
     public CommonResponseEntity<RecentProcedureResponse> getRecentProcedure(
-            @PathVariable Long shopId) {
-        return CommonResponseEntity.success(homeFacade.getRecentProcedure(shopId));
+            @RequestHeader("authorization_user") String token) {
+        return CommonResponseEntity.success(homeFacade.getRecentProcedure(token));
     }
 
     // DURI-265 : 당일 스케줄 조회
-    @GetMapping("/schedule/{shopId}")
+    @GetMapping("/schedule")
     public CommonResponseEntity<List<TodayScheduleResponse>> getTodaySchedule(
-            @PathVariable Long shopId) {
-        return CommonResponseEntity.success(homeFacade.getTodaySchedule(shopId));
+            @RequestHeader("authorization_user") String token) {
+        return CommonResponseEntity.success(homeFacade.getTodaySchedule(token));
     }
 
     // DURI-266 : 미용 완료 여부 수정
@@ -48,9 +49,9 @@ public class GroomerHomeController {
     }
 
     // DURI-325 : 받은 견적요청서 리스트 조회
-    @GetMapping("/request/{shopId}")
+    @GetMapping("/request")
     public CommonResponseEntity<List<HomeQuotationReqResponse>> getRequestList(
-            @PathVariable Long shopId) {
-        return CommonResponseEntity.success(homeFacade.getRequestList(shopId));
+            @RequestHeader("authorization_user") String token) {
+        return CommonResponseEntity.success(homeFacade.getRequestList(token));
     }
 }

--- a/app/src/main/java/kr/com/duri/groomer/controller/GroomerHomeController.java
+++ b/app/src/main/java/kr/com/duri/groomer/controller/GroomerHomeController.java
@@ -28,14 +28,14 @@ public class GroomerHomeController {
     // DURI-221 : 가까운 시술정보 조회
     @GetMapping("/closet")
     public CommonResponseEntity<RecentProcedureResponse> getRecentProcedure(
-            @RequestHeader("authorization_user") String token) {
+            @RequestHeader("authorization_shop") String token) {
         return CommonResponseEntity.success(homeFacade.getRecentProcedure(token));
     }
 
     // DURI-265 : 당일 스케줄 조회
     @GetMapping("/schedule")
     public CommonResponseEntity<List<TodayScheduleResponse>> getTodaySchedule(
-            @RequestHeader("authorization_user") String token) {
+            @RequestHeader("authorization_shop") String token) {
         return CommonResponseEntity.success(homeFacade.getTodaySchedule(token));
     }
 
@@ -51,7 +51,7 @@ public class GroomerHomeController {
     // DURI-325 : 받은 견적요청서 리스트 조회
     @GetMapping("/request")
     public CommonResponseEntity<List<HomeQuotationReqResponse>> getRequestList(
-            @RequestHeader("authorization_user") String token) {
+            @RequestHeader("authorization_shop") String token) {
         return CommonResponseEntity.success(homeFacade.getRequestList(token));
     }
 }

--- a/app/src/main/java/kr/com/duri/groomer/controller/ShopController.java
+++ b/app/src/main/java/kr/com/duri/groomer/controller/ShopController.java
@@ -25,7 +25,7 @@ public class ShopController {
     // DURI-260 : 매장 상세정보 조회
     @GetMapping
     public CommonResponseEntity<ShopDetailResponse> getShopDetail(
-            @RequestHeader("authorization_user") String token) {
+            @RequestHeader("authorization_shop") String token) {
         return CommonResponseEntity.success(shopFacade.getShopDetail(token));
     }
 
@@ -56,7 +56,7 @@ public class ShopController {
     // DURI-322 : 이번달 총 매출 조회
     @GetMapping("/income")
     public CommonResponseEntity<MonthIncomeResponse> getMonthIncome(
-            @RequestHeader("authorization_user") String token) {
+            @RequestHeader("authorization_shop") String token) {
         return CommonResponseEntity.success(shopFacade.getMonthIncome(token));
     }
 

--- a/app/src/main/java/kr/com/duri/groomer/controller/ShopController.java
+++ b/app/src/main/java/kr/com/duri/groomer/controller/ShopController.java
@@ -10,7 +10,7 @@ import kr.com.duri.groomer.application.facade.ShopFacade;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,9 +23,10 @@ public class ShopController {
     private final ShopFacade shopFacade;
 
     // DURI-260 : 매장 상세정보 조회
-    @GetMapping("/{shopId}")
-    public CommonResponseEntity<ShopDetailResponse> getShopDetail(@PathVariable Long shopId) {
-        return CommonResponseEntity.success(shopFacade.getShopDetail(shopId));
+    @GetMapping
+    public CommonResponseEntity<ShopDetailResponse> getShopDetail(
+            @RequestHeader("authorization_user") String token) {
+        return CommonResponseEntity.success(shopFacade.getShopDetail(token));
     }
 
     // 주변 매장 리스트 조회
@@ -53,9 +54,10 @@ public class ShopController {
     }
 
     // DURI-322 : 이번달 총 매출 조회
-    @GetMapping("/income/{shopId}")
-    public CommonResponseEntity<MonthIncomeResponse> getMonthIncome(@PathVariable Long shopId) {
-        return CommonResponseEntity.success(shopFacade.getMonthIncome(shopId));
+    @GetMapping("/income")
+    public CommonResponseEntity<MonthIncomeResponse> getMonthIncome(
+            @RequestHeader("authorization_user") String token) {
+        return CommonResponseEntity.success(shopFacade.getMonthIncome(token));
     }
 
     // 주변 매장 검색

--- a/app/src/main/java/kr/com/duri/user/application/facade/ReviewFacade.java
+++ b/app/src/main/java/kr/com/duri/user/application/facade/ReviewFacade.java
@@ -41,13 +41,13 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class ReviewFacade {
 
-    private final ReviewImageService reviewImageService;
-    private final ReviewService reviewService;
-    private final ReviewMapper reviewMapper;
-    private final GroomerService groomerService;
-    private final ShopService shopService;
     private final PetService petService;
+    private final ShopService shopService;
+    private final GroomerService groomerService;
     private final QuotationService quotationService;
+    private final ReviewService reviewService;
+    private final ReviewImageService reviewImageService;
+    private final ReviewMapper reviewMapper;
 
     // 미용사 조회
     private Groomer getGroomer(Long shopId) {
@@ -90,7 +90,8 @@ public class ReviewFacade {
     }
 
     // 매장 리뷰 리스트 조회 (매장)
-    public List<ShopReviewResponse> getReviewsByShopId(Long shopId) {
+    public List<ShopReviewResponse> getReviewsByShopId(String token) {
+        Long shopId = shopService.getShopIdByToken(token);
         getShop(shopId);
         // 1. 매장으로 리뷰 조회
         List<Review> reviewList = reviewService.getReviewsByShopId(shopId);
@@ -112,7 +113,8 @@ public class ReviewFacade {
     }
 
     // 매장 리뷰 상세 리스트 조회 (매장)
-    public List<ShopReviewDetailResponse> getReviewsDetailByShopId(Long shopId) {
+    public List<ShopReviewDetailResponse> getReviewsDetailByShopId(String token) {
+        Long shopId = shopService.getShopIdByToken(token);
         List<Review> reviewDetailList = reviewService.getReviewsByShopId(shopId);
         if (reviewDetailList.isEmpty()) { // 해당 리뷰 없음
             return Collections.emptyList();
@@ -136,7 +138,8 @@ public class ReviewFacade {
     }
 
     // 내가 쓴 후기 목록 조회 (고객)
-    public UserReviewResponseList getReviewsByUserId(Long userId) {
+    public UserReviewResponseList getReviewsByUserId(String token) {
+        Long userId = shopService.getShopIdByToken(token);
         // 1. 반려견 조회
         Pet pet = petService.getPetByUserId(userId);
         // 2. 리뷰 목록 조회

--- a/app/src/main/java/kr/com/duri/user/application/facade/UserHomeFacade.java
+++ b/app/src/main/java/kr/com/duri/user/application/facade/UserHomeFacade.java
@@ -97,7 +97,8 @@ public class UserHomeFacade {
     }
 
     // 마지막 미용일자 및 최근 예약정보 조회
-    public RecentProcedureResponse getRecentProcedure(Long userId) {
+    public RecentProcedureResponse getRecentProcedure(String token) {
+        Long userId = siteUserService.getUserIdByToken(token);
         getUser(userId);
         // 1. 반려견, 마지막 미용일로부터 지난일
         Pet pet = petService.findById(userId);
@@ -124,10 +125,11 @@ public class UserHomeFacade {
     }
 
     // 단골샵 조회
-    public RegularShopResponse getRegularShops(Long userId) {
+    public RegularShopResponse getRegularShops(String token) {
+        Long userId = siteUserService.getUserIdByToken(token);
         getUser(userId);
         // 1. 사용자 아이디로 반려견 조회
-        Pet pet = petService.findById(userId);
+        Pet pet = petService.getPetByUserId(userId);
         Long petId = pet.getId();
         // 2. 반려견 아이디로 단골샵 매장 (3번 이상, 가장 많은 방문횟수) 조회
         List<Object[]> regularVisitInfo = quotationService.getRegularInfoByPetId(petId);
@@ -160,7 +162,8 @@ public class UserHomeFacade {
     }
 
     // 매장 추천
-    public List<RecommendShopResponse> getRecommendShops(Long userId, Double lat, Double lon) {
+    public List<RecommendShopResponse> getRecommendShops(String token, Double lat, Double lon) {
+        Long userId = siteUserService.getUserIdByToken(token);
         Pet pet = petService.findById(userId);
         // 1. 주변 매장 계산
         List<Shop> nearbyShops = getNearbyShops(lat, lon);
@@ -311,7 +314,8 @@ public class UserHomeFacade {
     }
 
     // 펫 간단 정보 조회
-    public HomePetInfoResponse getPetInfo(Long userId) {
+    public HomePetInfoResponse getPetInfo(String token) {
+        Long userId = siteUserService.getUserIdByToken(token);
         getUser(userId);
         Pet pet = petService.getPetByUserId(userId);
         String gender = userHomeMapper.translateGender(pet.getGender());

--- a/app/src/main/java/kr/com/duri/user/application/facade/UserInfoFacade.java
+++ b/app/src/main/java/kr/com/duri/user/application/facade/UserInfoFacade.java
@@ -68,8 +68,8 @@ public class UserInfoFacade {
     }
 
     // 고객의 이용기록 조회
-    public List<HistoryResponse> getHistoryList(Long userId) {
-        siteUserService.getSiteUserById(userId);
+    public List<HistoryResponse> getHistoryList(String token) {
+        Long userId = siteUserService.getUserIdByToken(token);
         Pet pet = petService.getPetByUserId(userId);
         // 1. 해당 유저의 이용 기록 가져오기
         List<Quotation> quotationList = quotationService.getHistoryByPetId(pet.getId());

--- a/app/src/main/java/kr/com/duri/user/controller/ReviewController.java
+++ b/app/src/main/java/kr/com/duri/user/controller/ReviewController.java
@@ -37,14 +37,14 @@ public class ReviewController {
     // DURI-294 : 매장 리뷰 리스트 조회 (미용사)
     @GetMapping("/shop/review")
     public CommonResponseEntity<List<ShopReviewResponse>> getShopReviewList(
-            @RequestHeader("authorization_user") String token) {
+            @RequestHeader("authorization_shop") String token) {
         return CommonResponseEntity.success(reviewFacade.getReviewsByShopId(token));
     }
 
     // DURI-324 : 매장 리뷰 상세 리스트 조회 (미용사)
     @GetMapping("/shop/review-detail")
     public CommonResponseEntity<List<ShopReviewDetailResponse>> getReviewDetailList(
-            @RequestHeader("authorization_user") String token) {
+            @RequestHeader("authorization_shop") String token) {
         return CommonResponseEntity.success(reviewFacade.getReviewsDetailByShopId(token));
     }
 

--- a/app/src/main/java/kr/com/duri/user/controller/ReviewController.java
+++ b/app/src/main/java/kr/com/duri/user/controller/ReviewController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -34,24 +35,24 @@ public class ReviewController {
     private final ReviewFacade reviewFacade;
 
     // DURI-294 : 매장 리뷰 리스트 조회 (미용사)
-    @GetMapping("/shop/review/{shopId}")
+    @GetMapping("/shop/review")
     public CommonResponseEntity<List<ShopReviewResponse>> getShopReviewList(
-            @PathVariable Long shopId) {
-        return CommonResponseEntity.success(reviewFacade.getReviewsByShopId(shopId));
+            @RequestHeader("authorization_user") String token) {
+        return CommonResponseEntity.success(reviewFacade.getReviewsByShopId(token));
     }
 
     // DURI-324 : 매장 리뷰 상세 리스트 조회 (미용사)
-    @GetMapping("/shop/review-detail/{shopId}")
+    @GetMapping("/shop/review-detail")
     public CommonResponseEntity<List<ShopReviewDetailResponse>> getReviewDetailList(
-            @PathVariable Long shopId) {
-        return CommonResponseEntity.success(reviewFacade.getReviewsDetailByShopId(shopId));
+            @RequestHeader("authorization_user") String token) {
+        return CommonResponseEntity.success(reviewFacade.getReviewsDetailByShopId(token));
     }
 
     // DURI-288 : 내가 쓴 후기 목록 조회 (고객)
-    @GetMapping("/user/review/{userId}")
+    @GetMapping("/user/review")
     public CommonResponseEntity<UserReviewResponseList> getUserReviewList(
-            @PathVariable Long userId) {
-        return CommonResponseEntity.success(reviewFacade.getReviewsByUserId(userId));
+            @RequestHeader("authorization_user") String token) {
+        return CommonResponseEntity.success(reviewFacade.getReviewsByUserId(token));
     }
 
     // DURI-286 : 리뷰 작성 (고객)

--- a/app/src/main/java/kr/com/duri/user/controller/UserHomeController.java
+++ b/app/src/main/java/kr/com/duri/user/controller/UserHomeController.java
@@ -11,7 +11,7 @@ import kr.com.duri.user.application.facade.UserHomeFacade;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,36 +24,40 @@ public class UserHomeController {
     private final UserHomeFacade userHomeFacade;
 
     // DURI-275 : 마지막 미용일자 및 최근 예약정보 조회
-    @GetMapping("/schedule/{userId}")
+    @GetMapping("/schedule")
     public CommonResponseEntity<RecentProcedureResponse> getReservationInfo(
-            @PathVariable Long userId) {
-        RecentProcedureResponse recentProcedureResponse = userHomeFacade.getRecentProcedure(userId);
+            @RequestHeader("authorization_user") String token) {
+        RecentProcedureResponse recentProcedureResponse = userHomeFacade.getRecentProcedure(token);
         return CommonResponseEntity.success(recentProcedureResponse);
     }
 
     // DURI-271 : 단골샵 조회
-    @GetMapping("/regular/{userId}")
-    public CommonResponseEntity<RegularShopResponse> getRegularInfo(@PathVariable Long userId) {
-        RegularShopResponse regularShopResponses = userHomeFacade.getRegularShops(userId);
+    @GetMapping("/regular")
+    public CommonResponseEntity<RegularShopResponse> getRegularInfo(
+            @RequestHeader("authorization_user") String token) {
+        RegularShopResponse regularShopResponses = userHomeFacade.getRegularShops(token);
         return CommonResponseEntity.success(regularShopResponses);
     }
 
     // DURI-334 : 펫 간단 정보 조회
-    @GetMapping("/pet/{userId}")
-    public CommonResponseEntity<HomePetInfoResponse> getPetInfo(@PathVariable Long userId) {
-        HomePetInfoResponse homePetInfoResponse = userHomeFacade.getPetInfo(userId);
+    @GetMapping("/pet")
+    public CommonResponseEntity<HomePetInfoResponse> getPetInfo(
+            @RequestHeader("authorization_user") String token) {
+        HomePetInfoResponse homePetInfoResponse = userHomeFacade.getPetInfo(token);
         return CommonResponseEntity.success(homePetInfoResponse);
     }
 
     // DURI-329 : 추천 매장 조회
     @GetMapping("/recommend/{userId}")
     public CommonResponseEntity<List<RecommendShopResponse>> getRecommendShops(
-            @PathVariable Long userId, @RequestParam Double lat, @RequestParam Double lon) {
+            @RequestHeader("authorization_user") String token,
+            @RequestParam Double lat,
+            @RequestParam Double lon) {
         // TODO : 매장 추천 조회 연결되는지 확인 후, 안되면 수도권 기준
         lat = (lat != null) ? 37.510257428761 : lat;
         lon = (lon != null) ? 127.04391561527 : lon;
         List<RecommendShopResponse> recommendShopResponses =
-                userHomeFacade.getRecommendShops(userId, lat, lon);
+                userHomeFacade.getRecommendShops(token, lat, lon);
         return CommonResponseEntity.success(recommendShopResponses);
     }
 }

--- a/app/src/main/java/kr/com/duri/user/controller/UserHomeController.java
+++ b/app/src/main/java/kr/com/duri/user/controller/UserHomeController.java
@@ -48,7 +48,7 @@ public class UserHomeController {
     }
 
     // DURI-329 : 추천 매장 조회
-    @GetMapping("/recommend/{userId}")
+    @GetMapping("/recommend")
     public CommonResponseEntity<List<RecommendShopResponse>> getRecommendShops(
             @RequestHeader("authorization_user") String token,
             @RequestParam Double lat,

--- a/app/src/main/java/kr/com/duri/user/controller/UserInfoController.java
+++ b/app/src/main/java/kr/com/duri/user/controller/UserInfoController.java
@@ -33,10 +33,10 @@ public class UserInfoController {
     }
 
     // DURI-329 : 이용기록 조회
-    @GetMapping("/history/{userId}")
+    @GetMapping("/history")
     public CommonResponseEntity<List<MonthlyHistoryResponse>> getHistory(
-            @PathVariable Long userId) {
-        List<HistoryResponse> historyResponseList = userInfoFacade.getHistoryList(userId);
+            @RequestHeader("authorization_user") String token) {
+        List<HistoryResponse> historyResponseList = userInfoFacade.getHistoryList(token);
         List<MonthlyHistoryResponse> monthlyHistoryResponseList =
                 userInfoFacade.getMonthlyHistory(historyResponseList);
         return CommonResponseEntity.success(monthlyHistoryResponseList);


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- DURI-ETC (임의 이슈번호)

## PR 개요

- 전체 코드에서 userId와 shopId를 컨트롤러에서 RequestParam으로 받았던 부분들을
RequestHeader로 모두 수정한 사항밖에 없습니닷

## Screenshots
- 구현 화면
  고객과 미용사 모든 api 테스트 결과, 기존과 동일하게 다 잘 작동하는 것을 확인했습니다.!!
![image](https://github.com/user-attachments/assets/24afd181-c35d-48dd-9609-9f6171412a4a)