### PR TITLE
[Feat] 매장 이미지 단일, 리스트 조회 로직 (-)

### DIFF
--- a/app/src/main/java/kr/com/duri/groomer/application/service/ShopImageService.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/ShopImageService.java
@@ -1,0 +1,17 @@
+package kr.com.duri.groomer.application.service;
+
+import java.util.List;
+
+import kr.com.duri.groomer.domain.Enum.ImageCategory;
+import kr.com.duri.groomer.domain.entity.Shop;
+import kr.com.duri.groomer.domain.entity.ShopImage;
+
+public interface ShopImageService {
+    ShopImage getMainShopImage(Shop shop);
+
+    List<ShopImage> getShopImagesList(Shop shop);
+
+    List<ShopImage> getShopImagesListWithCategory(Shop shop, ImageCategory category);
+
+    List<ShopImage> getShopImagesListWithCategoryNot(Shop shop, ImageCategory category);
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/service/impl/ShopImageServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/impl/ShopImageServiceImpl.java
@@ -1,0 +1,42 @@
+package kr.com.duri.groomer.application.service.impl;
+
+import java.util.List;
+
+import kr.com.duri.groomer.application.service.ShopImageService;
+import kr.com.duri.groomer.domain.Enum.ImageCategory;
+import kr.com.duri.groomer.domain.entity.Shop;
+import kr.com.duri.groomer.domain.entity.ShopImage;
+import kr.com.duri.groomer.repository.ShopImageRepository;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ShopImageServiceImpl implements ShopImageService {
+
+    private final ShopImageRepository shopImageRepository;
+
+    @Override
+    public ShopImage getMainShopImage(Shop shop) {
+        return shopImageRepository.findShopImageByShopAndCategory(shop, ImageCategory.MAIN);
+    }
+
+    @Override
+    public List<ShopImage> getShopImagesList(Shop shop) {
+        return shopImageRepository.findShopImagesByShopAndCategoryNotOrderByCreatedAtDesc(
+                shop, ImageCategory.MAIN);
+    }
+
+    @Override
+    public List<ShopImage> getShopImagesListWithCategory(Shop shop, ImageCategory category) {
+        return shopImageRepository.findShopImagesByShopAndCategoryOrderByCreatedAtDesc(
+                shop, category);
+    }
+
+    @Override
+    public List<ShopImage> getShopImagesListWithCategoryNot(Shop shop, ImageCategory category) {
+        return shopImageRepository.findShopImagesByShopAndCategoryNotOrderByCreatedAtDesc(
+                shop, category);
+    }
+}

--- a/app/src/main/java/kr/com/duri/groomer/domain/Enum/ImageCategory.java
+++ b/app/src/main/java/kr/com/duri/groomer/domain/Enum/ImageCategory.java
@@ -1,0 +1,10 @@
+package kr.com.duri.groomer.domain.Enum;
+
+public enum ImageCategory {
+    // memo : 카테고리 (매장이미지(MAIN), 가격표 이미지(PRICE), 사업자등록증(BUSINESS), 기타(ETC))
+    // 우선은 메인과 그 외로 구분할거 같습니다.
+    MAIN,
+    PRICE,
+    BUSINESS,
+    ETC
+}

--- a/app/src/main/java/kr/com/duri/groomer/domain/entity/ShopImage.java
+++ b/app/src/main/java/kr/com/duri/groomer/domain/entity/ShopImage.java
@@ -3,6 +3,7 @@ package kr.com.duri.groomer.domain.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import kr.com.duri.common.entity.BaseEntity;
+import kr.com.duri.groomer.domain.Enum.ImageCategory;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,14 +23,14 @@ public class ShopImage extends BaseEntity {
     private Long id; // 매장 이미지 ID
 
     @NotBlank
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "shop_id")
     private Shop shop; // 매장 ID FK
 
     @Column(name = "shop_image_url")
     private String shopImageUrl; // 매장 이미지 URL
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "category")
-    // TODO : ENUM 변경
-    private String category; // 카테고리 (매장이미지(MAIN), 가격표 이미지(PRICE), 사업자등록증(BUSINESS), 기타(ETC))
+    private ImageCategory category; // 이미지 카테고리
 }

--- a/app/src/main/java/kr/com/duri/groomer/repository/ShopImageRepository.java
+++ b/app/src/main/java/kr/com/duri/groomer/repository/ShopImageRepository.java
@@ -1,0 +1,21 @@
+package kr.com.duri.groomer.repository;
+
+import java.util.List;
+
+import kr.com.duri.groomer.domain.Enum.ImageCategory;
+import kr.com.duri.groomer.domain.entity.Shop;
+import kr.com.duri.groomer.domain.entity.ShopImage;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShopImageRepository extends JpaRepository<ShopImage, Long> {
+    ShopImage findShopImageByShopAndCategory(Shop shop, ImageCategory category);
+
+    // 해당 매장의 이미지들을 카테고리별로 리스트 조회
+    List<ShopImage> findShopImagesByShopAndCategoryOrderByCreatedAtDesc(
+            Shop shop, ImageCategory category);
+
+    // 해당 매장의 이미지들을 선택 카테고리별 제외한 리스트 조회
+    List<ShopImage> findShopImagesByShopAndCategoryNotOrderByCreatedAtDesc(
+            Shop shop, ImageCategory category);
+}


### PR DESCRIPTION
# Pull Request

## 관련 이슈

## PR 개요

- 매장 이미지 조회해오는 로직을 개발했습니다.
- shopId만으로 조회를 가능하도록 하려했는데
> - 어차피 이미지 단일로 조회되는 경우가 없고 매장이 조회가 된다.
> - Id로 변경하기에는 다른 로직에서 연달아 변경되는 경우 우려.
> - shopId로 변경 시, 직접적으로 FK를 지정해주서 연관 관계가 사라지고, 무결성 관리는 별도로 해야한다.

등의 이유로 우선은 진행하는게 좋을거 같아 일단 그대로 진행하겠습니다. (차후 리팩토링 단계에서 고려해보면 좋을거 같습니다.)
- DTO도 같이 만들려했는데, 사용자에게 제공돼야할 정보가 String 밖에 없기도하고, 기존의 DTO에서 안에서 처리하는 것이 더 좋다고 판단하여 만들지는 않았습니다. 피드백 주시면 반영해보겠습니다.

## Screenshots