### PR TITLE
[Feat] 반려견 나이별, 질환별, 성격별, 키워드별 통계 조회(DURI-349)

### DIFF
--- a/app/src/main/java/kr/com/duri/groomer/application/dto/response/AgeStatisticsResponse.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/response/AgeStatisticsResponse.java
@@ -1,0 +1,17 @@
+package kr.com.duri.groomer.application.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AgeStatisticsResponse {
+    private Long shopId; // 매장 ID
+    private List<StatisticsResponse> ageList; // 나이별 누적 통계 리스트
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/response/BestStatisticsResponse.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/response/BestStatisticsResponse.java
@@ -1,0 +1,17 @@
+package kr.com.duri.groomer.application.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BestStatisticsResponse {
+    private Long shopId; // 매장 ID
+    private List<StatisticsResponse> bestList; // 각 최다 키워드 통계 리스트
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/response/CharacterStatisticsResponse.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/response/CharacterStatisticsResponse.java
@@ -1,0 +1,17 @@
+package kr.com.duri.groomer.application.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CharacterStatisticsResponse {
+    private Long shopId; // 매장 ID
+    private List<StatisticsResponse> characterList; // 성격별 누적 통계 리스트
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/response/DiseaseStatisticsResponse.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/response/DiseaseStatisticsResponse.java
@@ -1,0 +1,17 @@
+package kr.com.duri.groomer.application.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DiseaseStatisticsResponse {
+    private Long shopId; // 매장 ID
+    private List<StatisticsResponse> diseaseList; // 질환별 누적 통계 리스트
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/dto/response/StatisticsResponse.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/dto/response/StatisticsResponse.java
@@ -1,0 +1,16 @@
+package kr.com.duri.groomer.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StatisticsResponse {
+    private String standard; // 기준
+    private Float ratio; // 비율
+    private Long count; // 방문수
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/facade/StatisticsFacade.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/facade/StatisticsFacade.java
@@ -2,12 +2,19 @@ package kr.com.duri.groomer.application.facade;
 
 import java.util.List;
 
+import kr.com.duri.groomer.application.dto.response.AgeStatisticsResponse;
+import kr.com.duri.groomer.application.dto.response.BestStatisticsResponse;
+import kr.com.duri.groomer.application.dto.response.CharacterStatisticsResponse;
+import kr.com.duri.groomer.application.dto.response.DiseaseStatisticsResponse;
 import kr.com.duri.groomer.application.dto.response.FiveMonthIncomeResponse;
 import kr.com.duri.groomer.application.dto.response.IncomeResponse;
 import kr.com.duri.groomer.application.dto.response.SelectMonthIncomeResponse;
+import kr.com.duri.groomer.application.dto.response.StatisticsResponse;
 import kr.com.duri.groomer.application.dto.response.WeekIncomeResponse;
 import kr.com.duri.groomer.application.mapper.StatisticsMapper;
+import kr.com.duri.groomer.application.service.QuotationService;
 import kr.com.duri.groomer.application.service.ShopService;
+import kr.com.duri.groomer.application.service.StatisticsService;
 import kr.com.duri.groomer.domain.entity.Shop;
 import kr.com.duri.user.application.service.PaymentService;
 import lombok.RequiredArgsConstructor;
@@ -16,15 +23,17 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class StastisticsFacade {
+public class StatisticsFacade {
 
     private static final Integer PREVIOUS_IDX = 0;
     private static final Integer SELECT_IDX = 1;
     private static final Integer NOW_IDX = 2;
 
     private final ShopService shopService;
+    private final QuotationService quotationService;
     private final PaymentService paymentService;
     private final StatisticsMapper statisticsMapper;
+    private final StatisticsService statisticsService;
 
     // 매장 조회
     private Shop getShop(Long shopId) {
@@ -79,5 +88,42 @@ public class StastisticsFacade {
         // 최근 7일 조회
         List<IncomeResponse> monthIncomeResponses = paymentService.getWeekIncomes(shopId);
         return statisticsMapper.toWeekIncomeResponse(shop, monthIncomeResponses);
+    }
+
+    // 반려견 나이별 누적 조회
+    public AgeStatisticsResponse getAgeStastistics(String token) {
+        Long shopId = shopService.getShopIdByToken(token);
+        Shop shop = getShop(shopId);
+        // 나이별 조회
+        List<StatisticsResponse> ageResponses = statisticsService.getAgeStatistics(shopId);
+        return statisticsMapper.toAgeStastisticsResponse(shop, ageResponses);
+    }
+
+    // 반려견 질환별 누적 조회
+    public DiseaseStatisticsResponse getDiseaseStastistics(String token) {
+        Long shopId = shopService.getShopIdByToken(token);
+        Shop shop = getShop(shopId);
+        // 질환별 조회
+        List<StatisticsResponse> diseaseResponses = statisticsService.getDiseaseStatistics(shopId);
+        return statisticsMapper.toDiseaseStastisticsResponse(shop, diseaseResponses);
+    }
+
+    // 반려견 성격별 누적 조회
+    public CharacterStatisticsResponse getCharacterStastistics(String token) {
+        Long shopId = shopService.getShopIdByToken(token);
+        Shop shop = getShop(shopId);
+        // 성격별 조회
+        List<StatisticsResponse> characterResponses =
+                statisticsService.getCharacterStatistics(shopId);
+        return statisticsMapper.toCharacterStastisticsResponse(shop, characterResponses);
+    }
+
+    // 매장 최고 키워드별 조회
+    public BestStatisticsResponse getBestStastistics(String token) {
+        Long shopId = shopService.getShopIdByToken(token);
+        Shop shop = getShop(shopId);
+        // 성격별 조회
+        List<StatisticsResponse> bestResponses = statisticsService.getBestStatistics(shopId);
+        return statisticsMapper.toBestStatisticsResponse(shop, bestResponses);
     }
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/mapper/StatisticsMapper.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/mapper/StatisticsMapper.java
@@ -2,9 +2,14 @@ package kr.com.duri.groomer.application.mapper;
 
 import java.util.List;
 
+import kr.com.duri.groomer.application.dto.response.AgeStatisticsResponse;
+import kr.com.duri.groomer.application.dto.response.BestStatisticsResponse;
+import kr.com.duri.groomer.application.dto.response.CharacterStatisticsResponse;
+import kr.com.duri.groomer.application.dto.response.DiseaseStatisticsResponse;
 import kr.com.duri.groomer.application.dto.response.FiveMonthIncomeResponse;
 import kr.com.duri.groomer.application.dto.response.IncomeResponse;
 import kr.com.duri.groomer.application.dto.response.SelectMonthIncomeResponse;
+import kr.com.duri.groomer.application.dto.response.StatisticsResponse;
 import kr.com.duri.groomer.application.dto.response.WeekIncomeResponse;
 import kr.com.duri.groomer.domain.entity.Shop;
 
@@ -42,6 +47,47 @@ public class StatisticsMapper {
         return WeekIncomeResponse.builder()
                 .shopId(shop.getId())
                 .incomeMonthList(incomeMonthResponses)
+                .build();
+    }
+
+    // (기준, 개수, 비율) Object[] to StatisticsResponse DTO
+    public StatisticsResponse toStatisticsResponse(String standard, Long count, Float ratio) {
+        return StatisticsResponse.builder().standard(standard).count(count).ratio(ratio).build();
+    }
+
+    // Shop Entity, List<StatisticsResponse> to AgeStatisticsResponse DTO
+    public AgeStatisticsResponse toAgeStastisticsResponse(
+            Shop shop, List<StatisticsResponse> statisticsResponse) {
+        return AgeStatisticsResponse.builder()
+                .shopId(shop.getId())
+                .ageList(statisticsResponse)
+                .build();
+    }
+
+    // Shop Entity, List<StatisticsResponse> to DiseaseStatisticsResponse DTO
+    public DiseaseStatisticsResponse toDiseaseStastisticsResponse(
+            Shop shop, List<StatisticsResponse> statisticsResponse) {
+        return DiseaseStatisticsResponse.builder()
+                .shopId(shop.getId())
+                .diseaseList(statisticsResponse)
+                .build();
+    }
+
+    // Shop Entity, List<StatisticsResponse> to CharacterStatisticsResponse DTO
+    public CharacterStatisticsResponse toCharacterStastisticsResponse(
+            Shop shop, List<StatisticsResponse> statisticsResponse) {
+        return CharacterStatisticsResponse.builder()
+                .shopId(shop.getId())
+                .characterList(statisticsResponse)
+                .build();
+    }
+
+    // Shop Entity, List<StatisticsResponse> to CharacterStatisticsResponse DTO
+    public BestStatisticsResponse toBestStatisticsResponse(
+            Shop shop, List<StatisticsResponse> statisticsResponse) {
+        return BestStatisticsResponse.builder()
+                .shopId(shop.getId())
+                .bestList(statisticsResponse)
                 .build();
     }
 }

--- a/app/src/main/java/kr/com/duri/groomer/application/service/StatisticsService.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/StatisticsService.java
@@ -1,0 +1,20 @@
+package kr.com.duri.groomer.application.service;
+
+import java.util.List;
+
+import kr.com.duri.groomer.application.dto.response.StatisticsResponse;
+
+public interface StatisticsService {
+
+    // 나이별 통계
+    List<StatisticsResponse> getAgeStatistics(Long shopId);
+
+    // 질환별 통계
+    List<StatisticsResponse> getDiseaseStatistics(Long shopId);
+
+    // 성격별 통계
+    List<StatisticsResponse> getCharacterStatistics(Long shopId);
+
+    // 키워드별 통계
+    List<StatisticsResponse> getBestStatistics(Long shopId);
+}

--- a/app/src/main/java/kr/com/duri/groomer/application/service/impl/StatisticsServiceImpl.java
+++ b/app/src/main/java/kr/com/duri/groomer/application/service/impl/StatisticsServiceImpl.java
@@ -1,0 +1,112 @@
+package kr.com.duri.groomer.application.service.impl;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import kr.com.duri.groomer.application.dto.response.StatisticsResponse;
+import kr.com.duri.groomer.application.mapper.StatisticsMapper;
+import kr.com.duri.groomer.application.service.StatisticsService;
+import kr.com.duri.groomer.repository.QuotationRepository;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StatisticsServiceImpl implements StatisticsService {
+
+    private final QuotationRepository quotationRepository;
+    private final StatisticsMapper statisticsMapper;
+
+    // 비율 계산
+    private Float calculateRatio(Long count, Long totalCnt) {
+        return (totalCnt > 0) ? Math.round((count / (float) totalCnt) * 1000) / 10F : 0F;
+    }
+
+    // Age Object to DTO (Mapper)
+    private List<StatisticsResponse> calculateAgeStatistics(List<Object[]> data, Long totalCnt) {
+        return data.stream()
+                .map(
+                        group -> {
+                            String groupLabel = (String) group[0];
+                            Long count = (Long) group[1];
+                            Float ratio = calculateRatio(count, totalCnt);
+                            return statisticsMapper.toStatisticsResponse(groupLabel, count, ratio);
+                        })
+                .toList();
+    }
+
+    // Disease, Character Object to DTO (Mapper)
+    private List<StatisticsResponse> calculateEtcStatistics(
+            List<Map<String, Object>> data, Long totalCnt) {
+        return data.stream()
+                .flatMap(map -> map.entrySet().stream())
+                .map(
+                        entry -> {
+                            String label = entry.getKey();
+                            Long count =
+                                    entry.getValue() == null
+                                            ? 0L
+                                            : ((Number) entry.getValue()).longValue();
+                            Float ratio = calculateRatio(count, totalCnt);
+                            return statisticsMapper.toStatisticsResponse(label, count, ratio);
+                        })
+                .toList();
+    }
+
+    // 나이별 통계
+    @Override
+    public List<StatisticsResponse> getAgeStatistics(Long shopId) {
+        List<Object[]> ageList = quotationRepository.getPetAgeStatistics(shopId);
+        Long totalCnt = ageList.stream().mapToLong(group -> (Long) group[1]).sum();
+        return calculateAgeStatistics(ageList, totalCnt);
+    }
+
+    // 질환별 통계
+    @Override
+    public List<StatisticsResponse> getDiseaseStatistics(Long shopId) {
+        List<Map<String, Object>> diseaseList =
+                quotationRepository.getPetDiseaseCharacterStatistics(shopId);
+        Long totalCnt =
+                diseaseList.stream()
+                        .flatMap(map -> map.values().stream())
+                        .mapToLong(value -> value == null ? 0L : ((Number) value).longValue())
+                        .sum();
+        return calculateEtcStatistics(diseaseList, totalCnt);
+    }
+
+    // 성격별 통계
+    @Override
+    public List<StatisticsResponse> getCharacterStatistics(Long shopId) {
+        List<Map<String, Object>> characterList =
+                quotationRepository.getPetCharacterStatistics(shopId);
+        Long totalCnt =
+                characterList.stream()
+                        .flatMap(map -> map.values().stream())
+                        .mapToLong(value -> value == null ? 0L : ((Number) value).longValue())
+                        .sum();
+        return calculateEtcStatistics(characterList, totalCnt);
+    }
+
+    // 가장 큰 개수의 통계 값 찾기
+    private StatisticsResponse getBestStatistic(List<StatisticsResponse> statistics) {
+        return statistics.stream()
+                .max(Comparator.comparingLong(StatisticsResponse::getCount))
+                .orElse(null);
+    }
+
+    // 키워드별 통계
+    @Override
+    public List<StatisticsResponse> getBestStatistics(Long shopId) {
+        List<StatisticsResponse> bestStatistics = new ArrayList<>();
+        // 나이대 통계
+        bestStatistics.add(getBestStatistic(getAgeStatistics(shopId)));
+        // 성격별 통계
+        bestStatistics.add(getBestStatistic(getCharacterStatistics(shopId)));
+        // 질환별 통계
+        bestStatistics.add(getBestStatistic(getDiseaseStatistics(shopId)));
+        return bestStatistics.stream().filter(stat -> stat != null).toList();
+    }
+}

--- a/app/src/main/java/kr/com/duri/groomer/controller/StatisticsController.java
+++ b/app/src/main/java/kr/com/duri/groomer/controller/StatisticsController.java
@@ -1,10 +1,14 @@
 package kr.com.duri.groomer.controller;
 
 import kr.com.duri.common.response.CommonResponseEntity;
+import kr.com.duri.groomer.application.dto.response.AgeStatisticsResponse;
+import kr.com.duri.groomer.application.dto.response.BestStatisticsResponse;
+import kr.com.duri.groomer.application.dto.response.CharacterStatisticsResponse;
+import kr.com.duri.groomer.application.dto.response.DiseaseStatisticsResponse;
 import kr.com.duri.groomer.application.dto.response.FiveMonthIncomeResponse;
 import kr.com.duri.groomer.application.dto.response.SelectMonthIncomeResponse;
 import kr.com.duri.groomer.application.dto.response.WeekIncomeResponse;
-import kr.com.duri.groomer.application.facade.StastisticsFacade;
+import kr.com.duri.groomer.application.facade.StatisticsFacade;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,13 +22,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/statistics")
 public class StatisticsController {
 
-    private final StastisticsFacade stastisticsFacade;
+    private final StatisticsFacade statisticsFacade;
 
     // DURI-291 : 최근 5달 매출 조회
     @GetMapping("/income/five-month")
     public CommonResponseEntity<FiveMonthIncomeResponse> getFiveMonthIncomes(
             @RequestHeader("authorization_shop") String token) {
-        return CommonResponseEntity.success(stastisticsFacade.getFiveMonthIncomes(token));
+        return CommonResponseEntity.success(statisticsFacade.getFiveMonthIncomes(token));
     }
 
     // DURI-292 : 원하는 달 매출 조회
@@ -32,25 +36,41 @@ public class StatisticsController {
     public CommonResponseEntity<SelectMonthIncomeResponse> getMonthIncomes(
             @RequestHeader("authorization_shop") String token,
             @RequestParam("month") String month) {
-        return CommonResponseEntity.success(stastisticsFacade.getSelectMonthIncomes(token, month));
+        return CommonResponseEntity.success(statisticsFacade.getSelectMonthIncomes(token, month));
     }
 
     // DURI-348 : 최근 7일 매출 조회
     @GetMapping("/income/week")
     public CommonResponseEntity<WeekIncomeResponse> getMonthIncomes(
             @RequestHeader("authorization_shop") String token) {
-        return CommonResponseEntity.success(stastisticsFacade.getWeekIncomes(token));
+        return CommonResponseEntity.success(statisticsFacade.getWeekIncomes(token));
     }
 
     // DURI-349 : 반려견 나이별 누적 조회
-    // @GetMapping("/age")
+    @GetMapping("/age")
+    public CommonResponseEntity<AgeStatisticsResponse> getAgeStastistics(
+            @RequestHeader("authorization_shop") String token) {
+        return CommonResponseEntity.success(statisticsFacade.getAgeStastistics(token));
+    }
 
     // DURI-350 : 반려견 질환별 누적 조회
-    // @GetMapping("/disease")
+    @GetMapping("/disease")
+    public CommonResponseEntity<DiseaseStatisticsResponse> getDiseaseStastistics(
+            @RequestHeader("authorization_shop") String token) {
+        return CommonResponseEntity.success(statisticsFacade.getDiseaseStastistics(token));
+    }
 
     // DURI-351 : 반려견 성격별 누적 조회
-    // @GetMapping("/character")
+    @GetMapping("/character")
+    public CommonResponseEntity<CharacterStatisticsResponse> getCharacterStastistics(
+            @RequestHeader("authorization_shop") String token) {
+        return CommonResponseEntity.success(statisticsFacade.getCharacterStastistics(token));
+    }
 
     // DURI-352 : 매장 베스트 키워드 조회
-    // @GetMapping("/keyword")
+    @GetMapping("/keyword")
+    public CommonResponseEntity<BestStatisticsResponse> getBestStastistics(
+            @RequestHeader("authorization_shop") String token) {
+        return CommonResponseEntity.success(statisticsFacade.getBestStastistics(token));
+    }
 }

--- a/app/src/main/java/kr/com/duri/user/application/dto/response/HomePetInfoResponse.java
+++ b/app/src/main/java/kr/com/duri/user/application/dto/response/HomePetInfoResponse.java
@@ -18,5 +18,5 @@ public class HomePetInfoResponse {
     private Integer age; // 나이
     private Float weight; // 몸무게
     private String lastGrooming; // 마지막 미용일자
-    private boolean neutering; // 중성화 여부
+    private Boolean neutering; // 중성화 여부
 }


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- DURI-349, DURI-350, DURI-351,  DURI-352

## PR 개요
- 반려견 나이별, 질환별, 성격별, 매장 베스트 키워드 조회
  - 반려견 나이별 조회 : ~3세, 3세~7세, 7세~ 별 방문횟수 및 비율
  - 반려견 성격별 조회 : 예민해요, 낯가려요, ... 별 방문횟수 및 비율
  - 반려견 질환별 조회 : 귀질환, 기저질환, ... 별 방문횟수 및 비율
  - 매장 베스트 키워드 조회 : 위에서 도출한 방문횟수에 따라 가장 많은 횟수의 키워드 및 비율 조회
 

## Screenshots
- 화면 결과
![image](https://github.com/user-attachments/assets/5ca96022-ad13-4e19-bff1-34c097bf5c81)

- 나이별 조회 결과
![image](https://github.com/user-attachments/assets/68358cb7-cc88-48ed-8560-6293be1c55a2)

- 질환별 조회 결과
![image](https://github.com/user-attachments/assets/68d44926-812a-47dc-af3b-1e1cc73f1c07)

- 성격별 조회 결과
![image](https://github.com/user-attachments/assets/0cb27f4c-4489-4ac2-9df2-d0eedaa57e00)

- 매장 베스트 키워드 결과
![image](https://github.com/user-attachments/assets/d2da478c-0c63-4b0a-a862-345a4eb8634f)